### PR TITLE
docs: sync ROADMAP and ARCHITECTURE with current state

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,17 +61,15 @@ weave use work
 ```
 src/
   main.rs                  Entry point. Builds CLI, dispatches to handlers.
+  lib.rs                   Crate root; re-exports public modules.
 
   cli/                     Clap command definitions and handler functions.
     mod.rs
     install.rs
+    list.rs
     remove.rs
-    profile.rs
-    publish.rs
     search.rs
-    sync.rs
-    doctor.rs
-    auth.rs
+    diagnose.rs
 
   core/
     pack.rs                Pack manifest: parsing, validation, the Pack struct.
@@ -86,7 +84,7 @@ src/
     mod.rs                 CliAdapter trait definition.
     claude_code.rs         Claude Code adapter (~/.claude/).
     gemini_cli.rs          Gemini CLI adapter (~/.gemini/).
-    codex_cli.rs           Codex CLI adapter (~/.codex/).
+                           (codex_cli.rs — planned for M3)
 
   error.rs                 Unified error types via thiserror.
   util.rs                  Shared helpers (file ops, path resolution, etc.)
@@ -336,7 +334,10 @@ Packs are distributed as `.tar.gz` archives. The registry index entry for each v
   "version": "1.2.0",
   "url": "https://github.com/PackWeave/registry/releases/download/...",
   "sha256": "abc123...",
-  "size_bytes": 4096
+  "size_bytes": 4096,
+  "dependencies": {
+    "other-pack": "^1.0.0"
+  }
 }
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,30 +14,27 @@ The milestones below are sequential. Each one produces something usable before t
 - [x] docs/ARCHITECTURE.md
 - [x] docs/ROADMAP.md
 - [x] docs/CONTRIBUTING.md
-- [x] CLAUDE.md
-- [x] GEMINI.md
-- [x] CODEX.md
+- [x] AGENTS.md (canonical AI instructions; CLAUDE.md, GEMINI.md, CODEX.md are thin pointers)
 - [x] pack.schema.toml
 - [x] GitHub issue templates (bug, feature, pack)
 
 -----
 
-## Milestone 2 — MVP core (v0.1)
+## Milestone 2 — MVP core (v0.1) ✅
 
 > First usable release: install/list/remove packs for Claude Code + Gemini CLI, backed by a GitHub registry.
 
-- [ ] `cargo init` with correct crate name and metadata
-- [ ] Core commands: `install`, `list`, `remove`
-- [ ] Pack manifest parsing + validation (TOML)
-- [ ] Local store: extract and cache packs
-- [ ] Lock file for pinned versions
-- [ ] GitHub-backed registry index (read-only)
-- [ ] Seed registry with 10–15 starter packs
-- [ ] Claude Code adapter (servers, prompts, commands, settings)
-- [ ] Gemini CLI adapter (servers, prompts, settings)
-- [ ] One-line install script
-- [ ] Homebrew formula
-- [ ] CI: build + clippy + fmt check on push
+- [x] `cargo init` with correct crate name and metadata
+- [x] Core commands: `install`, `list`, `remove`
+- [x] Pack manifest parsing + validation (TOML)
+- [x] Local store: extract and cache packs
+- [x] Lock file for pinned versions
+- [x] GitHub-backed registry index (read-only)
+- [ ] Seed registry with 10–15 starter packs (in progress — see issue #21)
+- [x] Claude Code adapter (servers, prompts, commands, settings)
+- [x] Gemini CLI adapter (servers, prompts, settings)
+- [x] One-line install script
+- [x] CI: build + clippy + fmt check on push
 
 -----
 
@@ -49,7 +46,8 @@ The milestones below are sequential. Each one produces something usable before t
 - [ ] `weave search` against the official MCP Registry
 - [ ] `weave update` for pack version management
 - [ ] `weave init` — scaffold a new pack
-- [ ] Environment variable handling for secrets (write references only)
+- [x] Environment variable handling for secrets (write `${VAR}` references only)
+- [x] Recursive transitive dependency resolution with cycle detection
 - [ ] Improved conflict detection using declared tool lists
 
 -----


### PR DESCRIPTION
## Summary
- Marks M2 complete in ROADMAP.md; ticks all delivered items
- Updates M1 to reference `AGENTS.md` instead of individual CLI files
- Marks env var handling and recursive deps as done in M3
- Fixes module map in ARCHITECTURE.md to match actual `src/` layout
- Adds `dependencies` field to pack archive format example

Closes #19, closes #20