### PR TITLE
chore: establish Apache 2.0 compliance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright 2026 Brenno Rangel Ferrari
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "weave"
 version = "0.1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -181,7 +181,7 @@
       sure any free software license included in your Package is
       compatible with the Apache 2.0 license.
 
-      Copyright [yyyy] [name of copyright owner]
+      Copyright 2026 Brenno Rangel Ferrari
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+weave
+Copyright 2026 Brenno Rangel Ferrari
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
## Summary
- Fills the `[yyyy] [name of copyright owner]` placeholder in LICENSE with `2026 Brenno Rangel Ferrari`
- Adds a `NOTICE` file as required by Apache 2.0 section 4(d)
- Adds `SPDX-License-Identifier: Apache-2.0` header to `Cargo.toml`