### PR TITLE
docs(readme): restore aspirational content and add Homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ AI assistants working in this repo should read [`AGENTS.md`](./AGENTS.md).
 
 ## Installation
 
+**Homebrew (macOS and Linux):**
+
+```bash
+brew install PackWeave/tap/weave
+```
+
 **Shell script (macOS and Linux):**
 
 ```bash
@@ -99,6 +105,38 @@ weave search "browser automation"
 
 # Check CLI configuration health
 weave diagnose
+```
+
+---
+
+## Coming soon
+
+These features are actively planned. See [docs/ROADMAP.md](./docs/ROADMAP.md) for milestones and details.
+
+**v0.2 — Codex, profiles, and pack authoring:**
+
+```bash
+# Switch between named profiles (e.g. work, oss, personal)
+weave use work
+
+# Create a new pack scaffold
+weave init my-pack
+
+# Update installed packs to latest compatible versions
+weave update
+
+# Publish a pack to the registry
+weave publish my-pack
+```
+
+**v0.3 — Hooks, taps, and sync:**
+
+```bash
+# Add a community pack source
+weave tap add user/repo
+
+# Reapply the active profile (after manual config changes)
+weave sync
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds a **"Coming soon"** section after the current Usage section, showing planned commands (`weave use`, `weave init`, `weave update`, `weave publish`, `weave tap`, `weave sync`) grouped by milestone (v0.2 / v0.3) and clearly labeled as planned — preserves project vision without implying these are functional today
- Restores the **Homebrew install** section now that `PackWeave/homebrew-tap` exists

## Why

The README was recently trimmed of unimplemented commands to avoid misleading users. That was correct, but it also removed the product vision. This PR brings the vision back in a clearly-scoped section.

## Test plan

- [ ] Read through README rendered on GitHub — "Coming soon" section is clear and accurate
- [ ] Homebrew formula path (`PackWeave/tap/weave`) matches the tap repo convention

Built with Claude Code