### PR TITLE
docs(readme): full restructure as a product-first page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ weave install @webdev
                       ~/.claude/CLAUDE.md, ~/.claude/.packweave_manifest.json
         Gemini CLI:   ~/.gemini/settings.json, ~/.gemini/GEMINI.md,
                       ~/.gemini/.packweave_manifest.json
-        (+ project-scope equivalents when ./.claude/ or ./.gemini/ exist)
+        (+ project-scope equivalents when ./.claude/ or ./.gemini/ exist,
+           plus Claude Code's ./.mcp.json for project-scope MCP servers)
 ```
 
 Each CLI has its own **adapter** — a thin layer that knows exactly how to read and write that CLI's config format. Adapters never wipe your existing config. They only add, track, and cleanly remove what they own. A `weave remove` is surgical.
@@ -95,7 +96,7 @@ weave list
 weave diagnose
 ```
 
-That's it. Weave has written MCP server definitions, slash commands, and settings into your Claude Code and Gemini CLI config — without touching anything else.
+That's it. Weave has written the pack's MCP servers, system prompt, settings, and (for Claude Code) slash commands into your CLI config — tracking everything it wrote so `weave remove` can undo it cleanly.
 
 ---
 


### PR DESCRIPTION
## Summary

Complete README restructure. No information removed — everything reorganized and expanded for clarity and impact.

**Structure changes:**
- Sections reordered: hook → problem → how it works → install → quick start → commands → pack format → supported CLIs → tips → coming soon → docs
- Added build/license/platform/status badges
- "How it works" now includes a data-flow diagram showing exactly which files Weave touches per CLI
- Commands section has a full reference table + versioned install example (`@webdev@1.2.0`)
- Pack format section now lists all pack capabilities (deps, commands, prompts, settings, env vars) with links to schema + PACKS.md
- Supported CLIs table expanded with per-CLI feature breakdown
- Project-scope config section reformatted as a `> [!TIP]` GitHub admonition (renders nicely on GitHub)
- Bottom docs section is now a clean table

**Content additions:**
- Homebrew install restored (PackWeave/homebrew-tap exists)
- "Coming soon" v0.2/v0.3 blocks with concrete command examples

## Test plan

- [ ] View rendered README on GitHub — badges render, admonition renders, tables align
- [ ] Verify Homebrew formula path matches `PackWeave/homebrew-tap` convention
- [ ] Check that no information from the previous README was accidentally dropped

Built with Claude Code