### PR TITLE
refactor(adapters): remove with_home() footgun, always use with_home_and_project

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -53,14 +53,6 @@ impl ClaudeCodeAdapter {
     }
 
     #[cfg(test)]
-    pub fn with_home(home: PathBuf) -> Self {
-        Self {
-            home: Some(home.clone()),
-            project_root: home,
-        }
-    }
-
-    #[cfg(test)]
     pub fn with_home_and_project(home: PathBuf, project_root: PathBuf) -> Self {
         Self {
             home: Some(home),
@@ -933,7 +925,9 @@ mod tests {
     use tempfile::TempDir;
 
     fn test_adapter(dir: &TempDir) -> ClaudeCodeAdapter {
-        ClaudeCodeAdapter::with_home(dir.path().to_path_buf())
+        let no_project = dir.path().join("no-project");
+        std::fs::create_dir_all(&no_project).unwrap();
+        ClaudeCodeAdapter::with_home_and_project(dir.path().to_path_buf(), no_project)
     }
 
     fn test_pack(name: &str) -> ResolvedPack {

--- a/src/adapters/gemini_cli.rs
+++ b/src/adapters/gemini_cli.rs
@@ -47,14 +47,6 @@ impl GeminiCliAdapter {
         }
     }
 
-    /// Override the home directory for testing without writing to real `~/.gemini/`.
-    pub fn with_home(home: PathBuf) -> Self {
-        Self {
-            home: Some(home.clone()),
-            project_root: home,
-        }
-    }
-
     /// Override both home and project root for testing.
     pub fn with_home_and_project(home: PathBuf, project_root: PathBuf) -> Self {
         Self {
@@ -836,7 +828,9 @@ mod tests {
     use tempfile::TempDir;
 
     fn test_adapter(dir: &TempDir) -> GeminiCliAdapter {
-        GeminiCliAdapter::with_home(dir.path().to_path_buf())
+        let no_project = dir.path().join("no-project");
+        std::fs::create_dir_all(&no_project).unwrap();
+        GeminiCliAdapter::with_home_and_project(dir.path().to_path_buf(), no_project)
     }
 
     fn test_pack(name: &str) -> ResolvedPack {


### PR DESCRIPTION
## Summary

- Removes the `with_home(home: PathBuf)` test constructor from both `ClaudeCodeAdapter` and `GeminiCliAdapter`
- The constructor was a footgun: it silently set `project_root = home`, so any test that created `~/.claude/` for user-scope testing would also satisfy `has_project_scope()`, triggering unintended project-scope writes
- All tests now use `with_home_and_project(home, project_root)` with a dedicated non-overlapping directory as the project root

## Test plan

- [x] `cargo test` — 91 tests pass (54 unit + 37 integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

Closes #16

Built with Claude Code