### PR TITLE
feat(cli): improve weave list output with descriptions, targets, and servers

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -22,17 +22,22 @@ pub fn run() -> Result<()> {
 
     for installed in &profile.packs {
         // Try to load the full manifest from the store for rich details.
-        let detail = Store::load_pack(&installed.name, &installed.version).ok();
-
-        print!("  {} v{}", installed.name, installed.version);
-        println!();
-
-        if let Some(ref pack) = detail {
-            println!("    {}", pack.description);
-            println!("    Targets: {}", format_targets(&pack.targets));
-            if !pack.servers.is_empty() {
-                let names: Vec<&str> = pack.servers.iter().map(|s| s.name.as_str()).collect();
-                println!("    Servers: {}", names.join(", "));
+        match Store::load_pack(&installed.name, &installed.version) {
+            Ok(pack) => {
+                println!("  {} v{}", installed.name, installed.version);
+                println!("    {}", pack.description);
+                println!("    Targets: {}", format_targets(&pack.targets));
+                if !pack.servers.is_empty() {
+                    let names: Vec<&str> = pack.servers.iter().map(|s| s.name.as_str()).collect();
+                    println!("    Servers: {}", names.join(", "));
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "  warning: could not load manifest for {} v{}: {e}",
+                    installed.name, installed.version
+                );
+                println!("  {} v{}", installed.name, installed.version);
             }
         }
 


### PR DESCRIPTION
## Summary

Enhances `weave list` to show richer pack information. Closes #29.

**Before:** bare name + version
**After:** loads full manifest from store to display description, target CLIs, and server names.

```
Installed packs (profile: default):

  webdev v1.0.0
    Web development MCP stack
    Targets: Claude Code, Gemini CLI, Codex CLI
    Servers: puppeteer, filesystem

2 pack(s) installed.
```

Empty state: `No packs installed (profile: default).` with install suggestion.

Falls back to name+version if manifest can't be loaded (e.g. cache cleared).

## Test plan

- [x] 3 unit tests for `format_targets()` helper
- [x] `cargo test` — 228 tests pass
- [x] `cargo clippy -- -D warnings` — clean

Built with Claude Code