### PR TITLE
feat(cli): improve weave search output and add --target filter flag

### DIFF
--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -22,6 +22,7 @@ pub fn run(query: &str, target: Option<&str>) -> Result<()> {
                 VALID_TARGETS.join(", ")
             );
         }
+        eprintln!("note: --target filtering is not yet implemented; showing all results");
     }
 
     let config = Config::load().context("loading weave config")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ enum Commands {
         /// Search query
         query: String,
 
-        /// Filter results by target CLI (e.g., "claude_code", "gemini_cli", "codex_cli")
+        /// Filter results by target CLI (reserved, not yet active; e.g., "claude_code", "gemini_cli", "codex_cli")
         #[arg(short, long)]
         target: Option<String>,
     },


### PR DESCRIPTION
## Summary

Enhances `weave search` output formatting and adds a `--target` flag skeleton. Closes #28.

**Output improvements:**
- Header: `Search results for '<query>':`
- Each result: name + version, description, keywords (if present)
- Footer: `N pack(s) found.`
- No-results: actionable message pointing to the registry

**`--target` flag (`-t`):**
- `weave search web --target claude_code` — accepts `claude_code`, `gemini_cli`, `codex_cli`
- Validates the value immediately with a clear error for unknown targets
- Actual filtering is a TODO since `PackSummary` doesn't carry target data yet — the flag is wired up and validated so it's ready when the registry index adds targets

## Test plan

- [x] `cargo test` — 227 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

Built with Claude Code