### PR TITLE
docs: add rule against direct commits to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ The adapters are opaque. They expose only the `CliAdapter` trait. The core does 
 
 ## Git branch hygiene
 
+**Never commit directly to `main`.** All changes must go through a pull request, even docs-only changes. Create a feature branch, push it, and open a PR via `gh pr create`.
+
 **Before committing to any branch, verify its PR has not already been merged into `main`.**
 
 ```sh


### PR DESCRIPTION
## Summary
- Adds explicit rule to AGENTS.md: never commit directly to `main`, always use PRs
- Prevents orphaned commits when agents work in parallel worktrees

## Test plan
- [x] Docs-only change

Built with Claude Code