### PR TITLE
docs: add development conventions and refresh AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,11 @@ Read docs/ARCHITECTURE.md before writing any code. It defines the module structu
 ### Testing
 
 - Unit tests go in `#[cfg(test)]` blocks in the same file
-- Integration tests go in `tests/`
-- Adapter tests use fixture directories under `tests/fixtures/` — never write to the real `~/.claude/` in tests
-- No network calls in tests — mock the registry client
+- Integration tests go in `tests/` (adapter tests, init tests)
+- E2E tests go in `tests/e2e/` — invoke the `weave` binary as a subprocess with full isolation via `TestEnv` (mock HTTP registry, fake HOME, fake store). Gated with `#[cfg(not(target_os = "windows"))]`
+- Never write to the real `~/.claude/`, `~/.gemini/`, `~/.codex/` in tests — use `TempDir` and env var overrides (`WEAVE_TEST_STORE_DIR`, `WEAVE_REGISTRY_URL`, `HOME`)
+- No network calls in tests — use `wiremock` for HTTP mocking
+- Tests that mutate process-global env vars must use `#[serial]` from `serial_test` to prevent parallel races
 
 ### Naming
 


### PR DESCRIPTION
## Summary

Comprehensive update to AGENTS.md based on lessons learned during this development session. Adds new conventions, refreshes stale sections, and codifies decisions that were previously implicit.

### New conventions added
- **State safety** — validate preconditions before mutating; never strand users between old and new state
- **Skip-decision standards** — clear 3-part test for when skipping an issue is justified vs. when to fix it
- **Commit immediately** — never leave changes uncommitted in the working tree
- **PR assignee** — always assign PRs to the current user via `gh api user --jq .login`
- **Doc update contracts** — ARCHITECTURE.md is aspirational (never remove planned modules), AGENTS.md is current (must match `src/`)

### Refreshed sections
- **Testing** — updated to cover E2E tests (`tests/e2e/`), env var isolation (`WEAVE_TEST_STORE_DIR`, `WEAVE_REGISTRY_URL`), `wiremock`, `#[serial]`
- **Module map** — added `core/config.rs`, `core/mcp_registry.rs`, `core/conflict.rs`, `util.rs`

## Test plan
- [x] Docs-only change

Built with Claude Code