### PR TITLE
docs: remove status badge to fit badges on one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Weave
 
 [![Build](https://github.com/PackWeave/weave/actions/workflows/ci.yml/badge.svg)](https://github.com/PackWeave/weave/actions/workflows/ci.yml)
-![Status](https://img.shields.io/badge/status-milestone%203%20complete-green)
 [![Homebrew](https://img.shields.io/badge/homebrew-PackWeave%2Ftap-FBB040)](https://github.com/PackWeave/homebrew-tap)
 [![Registry](https://img.shields.io/badge/registry-browse%20packs-8B5CF6)](https://github.com/PackWeave/registry)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)


### PR DESCRIPTION
## Summary
Remove the "milestone 3 complete" status badge — it's internal jargon that goes stale with each milestone. 5 badges fit on one line: Build, Homebrew, Registry, Platform, License.