### PR TITLE
chore: disable attribution taglines

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
     "attribution": {
-        "commit": "Built with Claude Code",
-        "pr": "Built with Claude Code"
+        "commit": "",
+        "pr": ""
     }
 }


### PR DESCRIPTION
Set commit and PR attribution to empty string in .claude/settings.json.