### PR TITLE
fix: defer servers_map mutation until after file write in remove

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -316,6 +316,8 @@ impl ClaudeCodeAdapter {
         servers_map: &mut HashMap<String, String>,
     ) -> Result<()> {
         if !path.exists() {
+            // Config file absent — no file write needed; safe to clean up
+            // ownership tracking immediately since there is nothing to roll back.
             for s in servers_to_remove {
                 servers_map.remove(s);
             }
@@ -329,16 +331,41 @@ impl ClaudeCodeAdapter {
                 source: e,
             })?;
 
-        if let Some(mcp) = config.get_mut("mcpServers").and_then(|v| v.as_object_mut()) {
-            for server_name in servers_to_remove {
-                mcp.remove(server_name);
-                servers_map.remove(server_name);
+        match config.get_mut("mcpServers") {
+            Some(v) => {
+                let mcp = v.as_object_mut().ok_or_else(|| WeaveError::RemoveFailed {
+                    pack: String::new(),
+                    cli: "Claude Code".into(),
+                    reason: format!(
+                        "{}: `mcpServers` exists but is not a JSON object",
+                        path.display()
+                    ),
+                })?;
+                for server_name in servers_to_remove {
+                    mcp.remove(server_name);
+                }
+            }
+            None => {
+                // mcpServers key absent — no file mutation occurred; safe to clean
+                // up ownership tracking immediately since there is nothing to roll back.
+                for s in servers_to_remove {
+                    servers_map.remove(s);
+                }
+                return Ok(());
             }
         }
 
         // JSON serialization of a valid serde_json::Value cannot fail.
         let output = serde_json::to_string_pretty(&config).expect("JSON serialization cannot fail");
-        util::write_file(path, &output)
+        util::write_file(path, &output)?;
+
+        // Only mutate ownership tracking after the file write succeeds — otherwise
+        // an I/O error would silently drop entries from the manifest.
+        for s in servers_to_remove {
+            servers_map.remove(s);
+        }
+
+        Ok(())
     }
 
     /// Deep-merge settings fragment into the JSON file at `path`, recording

--- a/src/adapters/codex_cli.rs
+++ b/src/adapters/codex_cli.rs
@@ -292,11 +292,11 @@ impl CodexAdapter {
                 })?;
                 for server_name in servers_to_remove {
                     mcp.remove(server_name);
-                    servers_map.remove(server_name);
                 }
             }
             None => {
-                // mcp_servers key absent — nothing to remove from the file; clean up manifest.
+                // mcp_servers key absent — no file mutation occurred; safe to clean
+                // up ownership tracking immediately since there is nothing to roll back.
                 for s in servers_to_remove {
                     servers_map.remove(s);
                 }
@@ -304,7 +304,15 @@ impl CodexAdapter {
             }
         }
 
-        Self::write_config_toml(path, &config)
+        Self::write_config_toml(path, &config)?;
+
+        // Only mutate ownership tracking after the file write succeeds — otherwise
+        // an I/O error would silently drop entries from the manifest.
+        for s in servers_to_remove {
+            servers_map.remove(s);
+        }
+
+        Ok(())
     }
 
     /// Merge settings fragment (top-level keys only) into the TOML file at `path`.

--- a/src/adapters/gemini_cli.rs
+++ b/src/adapters/gemini_cli.rs
@@ -236,6 +236,8 @@ impl GeminiCliAdapter {
         servers_map: &mut HashMap<String, String>,
     ) -> Result<()> {
         if !path.exists() {
+            // Config file absent — no file write needed; safe to clean up
+            // ownership tracking immediately since there is nothing to roll back.
             for s in servers_to_remove {
                 servers_map.remove(s);
             }
@@ -249,16 +251,41 @@ impl GeminiCliAdapter {
                 source: e,
             })?;
 
-        if let Some(mcp) = config.get_mut("mcpServers").and_then(|v| v.as_object_mut()) {
-            for server_name in servers_to_remove {
-                mcp.remove(server_name);
-                servers_map.remove(server_name);
+        match config.get_mut("mcpServers") {
+            Some(v) => {
+                let mcp = v.as_object_mut().ok_or_else(|| WeaveError::RemoveFailed {
+                    pack: String::new(),
+                    cli: "Gemini CLI".into(),
+                    reason: format!(
+                        "{}: `mcpServers` exists but is not a JSON object",
+                        path.display()
+                    ),
+                })?;
+                for server_name in servers_to_remove {
+                    mcp.remove(server_name);
+                }
+            }
+            None => {
+                // mcpServers key absent — no file mutation occurred; safe to clean
+                // up ownership tracking immediately since there is nothing to roll back.
+                for s in servers_to_remove {
+                    servers_map.remove(s);
+                }
+                return Ok(());
             }
         }
 
         // JSON serialization of a valid serde_json::Value cannot fail.
         let output = serde_json::to_string_pretty(&config).expect("JSON serialization cannot fail");
-        util::write_file(path, &output)
+        util::write_file(path, &output)?;
+
+        // Only mutate ownership tracking after the file write succeeds — otherwise
+        // an I/O error would silently drop entries from the manifest.
+        for s in servers_to_remove {
+            servers_map.remove(s);
+        }
+
+        Ok(())
     }
 
     /// Deep-merge settings fragment into the JSON file at `path`.


### PR DESCRIPTION
## Summary

- Fixes #113: `remove_servers_from_file()` was mutating `servers_map` (ownership tracking) before the file write succeeded. If the write failed, the manifest would silently lose entries, breaking future remove/diagnose calls.
- Applied the same defensive pattern already used by `remove_settings_from_file()`: modify the config, write the file, and only then call `servers_map.remove()`.
- Fixed in all three adapters: `claude_code.rs`, `gemini_cli.rs`, `codex_cli.rs`.

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (318 tests, 0 failures)