### PR TITLE
fix: record project root in manifest before project-scope writes

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -805,15 +805,11 @@ impl CliAdapter for ClaudeCodeAdapter {
 
         // Project-scope — only if the user passed `--project` (opt-in).
         if self.has_project_scope() {
-            let mut project_manifest = self.load_project_manifest()?;
-            self.apply_project_servers(pack, &mut project_manifest)?;
-            self.save_project_manifest(&project_manifest)?;
-            self.apply_project_settings(pack, &mut project_manifest)?;
-            self.save_project_manifest(&project_manifest)?;
-
             // Record this project root in the user-scope manifest so `remove`
             // can clean up project-scope state regardless of the working directory
-            // when `weave remove` is later invoked.
+            // when `weave remove` is later invoked. We do this BEFORE the
+            // project-scope writes so that even if a mid-apply failure occurs,
+            // the root is already tracked and `weave remove` can clean it up.
             let root_str = self
                 .project_root
                 .canonicalize()
@@ -828,6 +824,12 @@ impl CliAdapter for ClaudeCodeAdapter {
                 roots.push(root_str);
             }
             self.save_manifest(&manifest)?;
+
+            let mut project_manifest = self.load_project_manifest()?;
+            self.apply_project_servers(pack, &mut project_manifest)?;
+            self.save_project_manifest(&project_manifest)?;
+            self.apply_project_settings(pack, &mut project_manifest)?;
+            self.save_project_manifest(&project_manifest)?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- Moves project root recording in `ClaudeCodeAdapter::apply()` to **before** the project-scope writes (`apply_project_servers` / `apply_project_settings`), so that even if a mid-apply failure occurs the root is already tracked in `manifest.project_dirs` and `weave remove` can clean it up.
- Gemini CLI and Codex CLI adapters were checked — they do not have `project_dirs` tracking, so this ordering issue does not apply to them.

Closes #111

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 318 tests pass (`cargo test`)