### PR TITLE
fix: expand skill allowed-tools and add shell fallbacks

### DIFF
--- a/.claude/skills/check-pr-review/SKILL.md
+++ b/.claude/skills/check-pr-review/SKILL.md
@@ -2,7 +2,7 @@
 name: check-pr-review
 description: Review all comments and reviews on a GitHub PR — inline code annotations, review verdicts (APPROVED / CHANGES_REQUESTED), and conversation threads. Classifies each as stale/valid/deferred/skip, fixes valid ones in the working tree, creates GitHub issues for deferred ones. Pass a PR number or omit to auto-detect from the current branch.
 argument-hint: <PR number> (optional)
-allowed-tools: Bash, Read, Edit, Write, Grep
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---
 
 ## PR context

--- a/.claude/skills/rust-pre-commit/SKILL.md
+++ b/.claude/skills/rust-pre-commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: rust-pre-commit
 description: Run the Weave quality gate (cargo fmt, clippy, tests) before committing. Use when you want to verify the working tree is clean and CI-ready.
-allowed-tools: Bash
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 ## Weave pre-commit quality gate

--- a/.claude/skills/weave-e2e/SKILL.md
+++ b/.claude/skills/weave-e2e/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weave-e2e
 description: Run the manual E2E validation checklist against real CLI installations on this machine. Tests weave against actual ~/.claude.json, ~/.gemini/settings.json, ~/.codex/config.toml — not mocks. Pass a flow name to run a targeted subset (install, profiles, search, remove, diagnose), or omit for the full suite.
-allowed-tools: Bash, Read
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
 ---
 
 ## Current state
@@ -10,7 +10,7 @@ allowed-tools: Bash, Read
 !`weave --version 2>/dev/null || (cd "${CLAUDE_PROJECT_DIR:-.}" && cargo build --release 2>/dev/null && echo "Built. Add target/release to PATH or use ./target/release/weave") || echo "ERROR: weave not in PATH and build failed"`
 
 ### Installed CLIs
-!`{ [ -d ~/.claude ] && echo "Claude Code: YES (~/.claude/)"; } 2>/dev/null; { [ -f ~/.gemini/settings.json ] && echo "Gemini CLI: YES (~/.gemini/settings.json)"; } 2>/dev/null; { [ -f ~/.codex/config.toml ] && echo "Codex CLI: YES (~/.codex/config.toml)"; } 2>/dev/null`
+!`{ [ -d ~/.claude ] && echo "Claude Code: YES (~/.claude/)"; } 2>/dev/null; { [ -f ~/.gemini/settings.json ] && echo "Gemini CLI: YES (~/.gemini/settings.json)"; } 2>/dev/null; { [ -f ~/.codex/config.toml ] && echo "Codex CLI: YES (~/.codex/config.toml)"; } 2>/dev/null; true`
 
 ### Active profile
 !`weave profile list 2>/dev/null || echo "weave not available"`

--- a/.claude/skills/weave-issue/SKILL.md
+++ b/.claude/skills/weave-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: weave-issue
 description: Create a well-formed GitHub issue for the weave project with current work context auto-injected. Pass a title and optional description as arguments.
-allowed-tools: Bash
+allowed-tools: Bash, Read, Grep, Glob
 ---
 
 ## Context

--- a/.claude/skills/weave-ship/SKILL.md
+++ b/.claude/skills/weave-ship/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: weave-ship
 description: Full Weave workflow from working changes to open PR. Runs quality gates, commits, pushes, and opens a PR with the correct assignee. Use when ready to ship a change. Pass the commit message as the argument.
-allowed-tools: Bash, Read, Edit
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 ---
 
 ## Current state
 
 - Branch: !`git branch --show-current`
 - Uncommitted changes: !`git status --short`
-- GitHub user: !`gh api user --jq .login`
+- GitHub user: !`gh api user --jq .login 2>/dev/null || echo "(not authenticated — run gh auth login)"`
 
 ## Commit message / PR title
 


### PR DESCRIPTION
## Summary

- **All 5 skills**: expanded `allowed-tools` to include `Read`, `Grep`, `Glob` (and `Write`/`Edit` where needed) so they can actually navigate the codebase when invoked
- **weave-e2e**: added `; true` to CLI detection command — prevents skill load failure on machines missing Gemini/Codex (last `[ -f ... ]` exited non-zero)
- **weave-ship**: added `|| echo` fallback on `gh api user` — prevents skill load failure when `gh` isn't authenticated

## Test plan

- [x] `/weave-e2e` now loads and runs full suite (10/10 flows passing)
- [ ] Verify `/weave-ship`, `/weave-issue`, `/check-pr-review`, `/rust-pre-commit` load without error