### PR TITLE
refactor: move adapter warning output to CLI layer (#112)

### DIFF
--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -983,11 +983,12 @@ impl CliAdapter for ClaudeCodeAdapter {
         Ok(())
     }
 
-    fn remove(&self, pack_name: &str) -> Result<()> {
+    fn remove(&self, pack_name: &str) -> Result<Vec<String>> {
         // Collect all project roots to clean up. We start from the user-scope
         // manifest (which records roots from previous `weave install` calls) and
         // also include the current directory in case the user installs and removes
         // from the same project or is on an older weave version without tracking.
+        let mut warnings: Vec<String> = Vec::new();
         let mut roots_to_clean: Vec<PathBuf> = Vec::new();
 
         // User-scope — only touch the manifest if it already exists.
@@ -1030,11 +1031,10 @@ impl CliAdapter for ClaudeCodeAdapter {
                 if let Err(e) = self.remove_from_project_root(pack_name, root, &known_server_names)
                 {
                     // Non-fatal: the project dir may have been deleted or moved.
-                    // Warn so the user can investigate if needed.
-                    eprintln!(
-                        "  warning: could not clean project scope in {}: {e}",
-                        root.display()
-                    );
+                    // Log internally and surface to the CLI layer.
+                    let msg = format!("could not clean project scope in {}: {e}", root.display());
+                    log::warn!("{}", msg);
+                    warnings.push(msg);
                     failed_roots.push(root.to_string_lossy().to_string());
                 }
             }
@@ -1051,7 +1051,7 @@ impl CliAdapter for ClaudeCodeAdapter {
             self.save_manifest(&manifest)?;
         }
 
-        Ok(())
+        Ok(warnings)
     }
 
     fn diagnose(&self) -> Result<Vec<DiagnosticIssue>> {

--- a/src/adapters/codex_cli.rs
+++ b/src/adapters/codex_cli.rs
@@ -789,7 +789,7 @@ impl CliAdapter for CodexAdapter {
         Ok(())
     }
 
-    fn remove(&self, pack_name: &str) -> Result<()> {
+    fn remove(&self, pack_name: &str) -> Result<Vec<String>> {
         // User-scope — only touch the manifest if it already exists.
         let manifest_path = self.manifest_path()?;
         if manifest_path.exists() {
@@ -810,7 +810,7 @@ impl CliAdapter for CodexAdapter {
             self.save_project_manifest(&project_manifest)?;
         }
 
-        Ok(())
+        Ok(vec![])
     }
 
     fn diagnose(&self) -> Result<Vec<DiagnosticIssue>> {

--- a/src/adapters/gemini_cli.rs
+++ b/src/adapters/gemini_cli.rs
@@ -718,7 +718,7 @@ impl CliAdapter for GeminiCliAdapter {
         Ok(())
     }
 
-    fn remove(&self, pack_name: &str) -> Result<()> {
+    fn remove(&self, pack_name: &str) -> Result<Vec<String>> {
         // User-scope — only touch the manifest if it already exists.
         let manifest_path = self.manifest_path()?;
         if manifest_path.exists() {
@@ -738,7 +738,7 @@ impl CliAdapter for GeminiCliAdapter {
             self.save_project_manifest(&project_manifest)?;
         }
 
-        Ok(())
+        Ok(vec![])
     }
 
     fn diagnose(&self) -> Result<Vec<DiagnosticIssue>> {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -61,7 +61,10 @@ pub trait CliAdapter: Send + Sync {
 
     /// Remove all contributions made by a pack.
     /// Must leave user's manual edits untouched.
-    fn remove(&self, pack_name: &str) -> Result<()>;
+    ///
+    /// Returns a list of non-fatal warnings (e.g. project-scope cleanup failures)
+    /// that the CLI layer should surface to the user.
+    fn remove(&self, pack_name: &str) -> Result<Vec<String>>;
 
     /// Verify the CLI's current config is consistent with installed packs.
     /// Returns a list of issues for `weave diagnose`.

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -319,8 +319,8 @@ mod tests {
         fn apply(&self, _pack: &crate::core::pack::ResolvedPack) -> crate::error::Result<()> {
             Ok(())
         }
-        fn remove(&self, _pack_name: &str) -> crate::error::Result<()> {
-            Ok(())
+        fn remove(&self, _pack_name: &str) -> crate::error::Result<Vec<String>> {
+            Ok(vec![])
         }
         fn diagnose(&self) -> crate::error::Result<Vec<DiagnosticIssue>> {
             Ok(self.issues.clone())

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -35,7 +35,12 @@ pub fn run(pack_name: &str) -> Result<()> {
         let mut adapter_errors: Vec<String> = Vec::new();
         for adapter in &adapters {
             match adapter.remove(name) {
-                Ok(()) => println!("    Removed from {}", adapter.name()),
+                Ok(warnings) => {
+                    println!("    Removed from {}", adapter.name());
+                    for w in warnings {
+                        eprintln!("  warning: {}: {w}", adapter.name());
+                    }
+                }
                 Err(e) => adapter_errors.push(format!("{}: {e}", adapter.name())),
             }
         }

--- a/src/cli/use_profile.rs
+++ b/src/cli/use_profile.rs
@@ -64,7 +64,12 @@ pub fn run(profile_name: Option<&str>) -> Result<()> {
         println!("  Removing {pack_name}...");
         for adapter in &installed_adapters {
             match adapter.remove(pack_name) {
-                Ok(()) => println!("    Removed from {}", adapter.name()),
+                Ok(warnings) => {
+                    println!("    Removed from {}", adapter.name());
+                    for w in warnings {
+                        eprintln!("  warning: {}: {w}", adapter.name());
+                    }
+                }
                 Err(e) => eprintln!("  warning: {}: {e}", adapter.name()),
             }
         }


### PR DESCRIPTION
## Summary

- Change `CliAdapter::remove()` return type from `Result<()>` to `Result<Vec<String>>` to surface non-fatal warnings
- Replace `eprintln!` in Claude Code adapter's project-root cleanup with `log::warn!` + collected warnings
- CLI handlers (`remove.rs`, `use_profile.rs`) now print warnings with adapter name prefix
- Gemini/Codex adapters updated to match new trait signature (return empty vec)

Closes #112

## Test plan

- [x] Existing remove tests pass with new signature
- [x] MockAdapter in diagnose tests updated
- [x] All tests pass