### PR TITLE
feat: support remote MCP servers (url/headers) in all adapters (#59)

### DIFF
--- a/src/adapters/codex_cli.rs
+++ b/src/adapters/codex_cli.rs
@@ -964,6 +964,13 @@ fn build_codex_server_config(server: &McpServer) -> std::result::Result<toml::Va
                 )
             })?;
             table.insert("url".into(), toml::Value::String(url.to_owned()));
+            if let Some(headers) = &server.headers {
+                let mut headers_table = toml::value::Table::new();
+                for (k, v) in headers {
+                    headers_table.insert(k.clone(), toml::Value::String(v.clone()));
+                }
+                table.insert("http_headers".into(), toml::Value::Table(headers_table));
+            }
         }
         _ => {
             // Stdio (default): requires `command`.

--- a/src/core/pack.rs
+++ b/src/core/pack.rs
@@ -424,4 +424,32 @@ url = "https://example.com/mcp"
         let result = Pack::from_toml(toml, &PathBuf::from("test.toml"));
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn parse_http_server_with_headers() {
+        let toml = r#"
+[pack]
+name = "test"
+version = "1.0.0"
+description = "Test"
+
+[[servers]]
+name = "remote-api"
+transport = "http"
+url = "https://api.example.com/mcp"
+
+[servers.headers]
+Authorization = "${API_KEY}"
+X-Custom = "static-value"
+"#;
+        let pack = Pack::from_toml(toml, &PathBuf::from("test.toml")).unwrap();
+        assert_eq!(pack.servers.len(), 1);
+        let server = &pack.servers[0];
+        assert_eq!(server.transport, Some(Transport::Http));
+        assert_eq!(server.url.as_deref(), Some("https://api.example.com/mcp"));
+        let headers = server.headers.as_ref().expect("headers should be present");
+        assert_eq!(headers["Authorization"], "${API_KEY}");
+        assert_eq!(headers["X-Custom"], "static-value");
+        assert!(server.command.is_none());
+    }
 }

--- a/tests/claude_code_adapter.rs
+++ b/tests/claude_code_adapter.rs
@@ -1082,6 +1082,51 @@ fn apply_http_server_without_url_returns_error() {
 }
 
 #[test]
+fn remove_http_server_cleans_up() {
+    let home = TempDir::new().unwrap();
+    setup_claude_home(&home);
+    let adapter = make_adapter(&home);
+
+    let server = McpServer {
+        name: "http-removable".into(),
+        package_type: None,
+        package: None,
+        command: None,
+        args: vec![],
+        url: Some("https://example.com/mcp".into()),
+        headers: Some(
+            [("Authorization".to_string(), "Bearer ${TOKEN}".to_string())]
+                .into_iter()
+                .collect(),
+        ),
+        transport: Some(Transport::Http),
+        tools: vec![],
+        env: std::collections::HashMap::new(),
+    };
+    let pack = pack_with_servers("http-remove-pack", vec![server]);
+    adapter.apply(&pack).unwrap();
+
+    // Verify it was written
+    let config = read_json(&home.path().join(".claude.json"));
+    assert!(
+        config["mcpServers"]["http-removable"].is_object(),
+        "HTTP server should be present after apply"
+    );
+
+    // Remove
+    adapter.remove("http-remove-pack").unwrap();
+
+    let config_after = read_json(&home.path().join(".claude.json"));
+    assert!(
+        config_after["mcpServers"]
+            .as_object()
+            .map(|m| !m.contains_key("http-removable"))
+            .unwrap_or(true),
+        "HTTP server should be removed after remove()"
+    );
+}
+
+#[test]
 fn apply_persists_manifest_after_each_step_even_if_later_step_fails() {
     let home = TempDir::new().unwrap();
     setup_claude_home(&home);

--- a/tests/codex_adapter.rs
+++ b/tests/codex_adapter.rs
@@ -426,6 +426,130 @@ fn apply_writes_url_for_http_transport() {
 }
 
 #[test]
+fn apply_http_server_writes_headers() {
+    let home = TempDir::new().unwrap();
+    setup_codex_home(&home);
+    let adapter = make_adapter(&home);
+
+    let server = McpServer {
+        name: "http-with-headers".into(),
+        package_type: None,
+        package: None,
+        command: None,
+        args: vec![],
+        url: Some("https://example.com/mcp".into()),
+        headers: Some(
+            [("Authorization".to_string(), "${API_KEY}".to_string())]
+                .into_iter()
+                .collect(),
+        ),
+        transport: Some(Transport::Http),
+        tools: vec![],
+        env: HashMap::new(),
+    };
+    let pack = pack_with_servers("http-headers-pack", vec![server]);
+    adapter.apply(&pack).unwrap();
+
+    let config_path = home.path().join(".codex/config.toml");
+    let config = read_toml(&config_path);
+    let entry = config["mcp_servers"]["http-with-headers"]
+        .as_table()
+        .expect("server entry should be a table");
+    assert_eq!(
+        entry["url"].as_str().unwrap(),
+        "https://example.com/mcp",
+        "url must be written"
+    );
+    let headers = entry["http_headers"]
+        .as_table()
+        .expect("http_headers subtable must exist");
+    assert_eq!(
+        headers["Authorization"].as_str().unwrap(),
+        "${API_KEY}",
+        "header value must preserve env var reference"
+    );
+    assert!(
+        entry.get("command").is_none(),
+        "command must not appear in HTTP server config"
+    );
+}
+
+#[test]
+fn apply_http_server_without_url_returns_error() {
+    let home = TempDir::new().unwrap();
+    setup_codex_home(&home);
+    let adapter = make_adapter(&home);
+
+    let server = McpServer {
+        name: "no-url-server".into(),
+        package_type: None,
+        package: None,
+        command: None,
+        args: vec![],
+        url: None,
+        headers: None,
+        transport: Some(Transport::Http),
+        tools: vec![],
+        env: HashMap::new(),
+    };
+    let pack = pack_with_servers("bad-http-pack", vec![server]);
+    let result = adapter.apply(&pack);
+    assert!(result.is_err(), "should fail when HTTP server has no url");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("url"),
+        "error message should mention the missing url field"
+    );
+}
+
+#[test]
+fn remove_http_server_cleans_up() {
+    let home = TempDir::new().unwrap();
+    setup_codex_home(&home);
+    let adapter = make_adapter(&home);
+
+    let server = McpServer {
+        name: "http-removable".into(),
+        package_type: None,
+        package: None,
+        command: None,
+        args: vec![],
+        url: Some("https://example.com/mcp".into()),
+        headers: Some(
+            [("Authorization".to_string(), "${API_KEY}".to_string())]
+                .into_iter()
+                .collect(),
+        ),
+        transport: Some(Transport::Http),
+        tools: vec![],
+        env: HashMap::new(),
+    };
+    let pack = pack_with_servers("http-remove-pack", vec![server]);
+    adapter.apply(&pack).unwrap();
+
+    // Verify it was written
+    let config_path = home.path().join(".codex/config.toml");
+    let config = read_toml(&config_path);
+    assert!(
+        config["mcp_servers"]["http-removable"].is_table(),
+        "server should be present after apply"
+    );
+
+    // Remove
+    adapter.remove("http-remove-pack").unwrap();
+
+    let config_after = read_toml(&config_path);
+    assert!(
+        config_after
+            .get("mcp_servers")
+            .and_then(|s| s.as_table())
+            .map(|t| !t.contains_key("http-removable"))
+            .unwrap_or(true),
+        "HTTP server should be removed after remove()"
+    );
+}
+
+#[test]
 fn apply_preserves_existing_user_servers() {
     let home = TempDir::new().unwrap();
     setup_codex_home(&home);

--- a/tests/gemini_adapter.rs
+++ b/tests/gemini_adapter.rs
@@ -1108,6 +1108,52 @@ fn apply_http_server_without_url_returns_error() {
 }
 
 #[test]
+fn remove_http_server_cleans_up() {
+    let home = TempDir::new().unwrap();
+    setup_gemini_home(&home);
+    let adapter = make_adapter(&home);
+
+    let server = McpServer {
+        name: "http-removable".into(),
+        package_type: None,
+        package: None,
+        command: None,
+        args: vec![],
+        url: Some("https://example.com/mcp".into()),
+        headers: Some(
+            [("Authorization".to_string(), "Bearer ${TOKEN}".to_string())]
+                .into_iter()
+                .collect(),
+        ),
+        transport: Some(Transport::Http),
+        tools: vec![],
+        env: HashMap::new(),
+    };
+    let pack = pack_with_servers("http-remove-pack", vec![server]);
+    adapter.apply(&pack).unwrap();
+
+    // Verify it was written
+    let settings_path = home.path().join(".gemini/settings.json");
+    let config = read_json(&settings_path);
+    assert!(
+        config["mcpServers"]["http-removable"].is_object(),
+        "HTTP server should be present after apply"
+    );
+
+    // Remove
+    adapter.remove("http-remove-pack").unwrap();
+
+    let config_after = read_json(&settings_path);
+    assert!(
+        config_after["mcpServers"]
+            .as_object()
+            .map(|m| !m.contains_key("http-removable"))
+            .unwrap_or(true),
+        "HTTP server should be removed after remove()"
+    );
+}
+
+#[test]
 fn apply_persists_manifest_after_each_step_even_if_later_step_fails() {
     let home = TempDir::new().unwrap();
     setup_gemini_home(&home);


### PR DESCRIPTION
## Summary
- Codex CLI adapter now writes `http_headers` TOML subtable for HTTP transport servers
- Claude Code and Gemini adapters already handled HTTP transport correctly (verified)
- Added integration tests for HTTP server apply/remove across all three adapters
- Added unit test for `pack.toml` parsing of HTTP servers with headers

## Test plan
- [x] Unit test: parse HTTP server with headers from pack.toml
- [x] Integration tests: Codex apply/remove HTTP servers with headers
- [x] Integration tests: Claude Code and Gemini remove HTTP server cleanup
- [x] All 379 tests pass, fmt/clippy clean

Closes #59