### PR TITLE
docs: add taps, hooks, and HTTP transport flows to E2E validation skill

### DIFF
--- a/.claude/skills/weave-e2e/SKILL.md
+++ b/.claude/skills/weave-e2e/SKILL.md
@@ -24,7 +24,7 @@ Run the E2E validation checklist from `.claude/skills/weave-e2e/checklist.md`.
 
 **Arguments:** `$ARGUMENTS`
 
-- If `$ARGUMENTS` is empty → run all 13 flows in order
+- If `$ARGUMENTS` is empty → run all flows in checklist order (Flows 1–13, then Flow 14: Cleanup last)
 - If `$ARGUMENTS` is `install` → run Flows 1 + 2
 - If `$ARGUMENTS` is `profiles` → run Flows 1 + 5
 - If `$ARGUMENTS` is `search` → run Flows 1 + 7
@@ -36,7 +36,7 @@ Run the E2E validation checklist from `.claude/skills/weave-e2e/checklist.md`.
 - If `$ARGUMENTS` is `tap` → run Flows 1 + 11
 - If `$ARGUMENTS` is `hooks` → run Flows 1 + 12
 - If `$ARGUMENTS` is `http` → run Flows 1 + 13
-- If `$ARGUMENTS` is `cleanup` → run Flow 10 only (safe to run any time)
+- If `$ARGUMENTS` is `cleanup` → run Flow 14 only (safe to run any time)
 
 ## Steps
 
@@ -48,13 +48,13 @@ Run the E2E validation checklist from `.claude/skills/weave-e2e/checklist.md`.
    c. Evaluate against expected output
    d. Mark ✓ (pass) or ✗ (fail) with a one-line explanation
 4. If a flow fails a critical step, note it and continue to the next flow (don't abort the whole suite)
-5. Always run Flow 10 (cleanup) at the end of the full suite, even if earlier flows failed
+5. Always run Flow 14 (Cleanup) at the end of the full suite, even if earlier flows failed
 6. Print the summary table from the checklist with actual ✓/✗ results filled in
 
 ## Important notes
 
 - This modifies **real** config files (`~/.claude.json`, `~/.gemini/settings.json`, `~/.codex/config.toml`)
-- The `e2e-validation` profile is used for isolation — always clean it up in Flow 10
+- The `e2e-validation` profile is used for isolation — always clean it up in Flow 14
 - If the machine doesn't have a particular CLI installed, mark those CLI-specific steps as `N/A`
 - If `weave` is not in PATH, look for it at `./target/release/weave` (build the project first)
 - Do not abort on first failure — the goal is a complete picture of what works and what doesn't

--- a/.claude/skills/weave-e2e/checklist.md
+++ b/.claude/skills/weave-e2e/checklist.md
@@ -221,7 +221,7 @@ PreToolUse = [{ matcher = "Bash", command = "echo e2e-hook-fired" }]
 | Step | Command | Expected |
 |------|---------|----------|
 | 12.1 | Create pack dir + `pack.toml` as above | Files exist |
-| 12.2 | `weave install /tmp/weave-e2e-hooks` | Exits 0, output mentions hooks were skipped / pass --allow-hooks |
+| 12.2 | `weave install /tmp/weave-e2e-hooks` | Exits 0, output notes the pack declares hooks and instructs to pass `--allow-hooks` to apply them |
 | 12.3 | `weave list` | Shows `e2e-hooks-test` with `[hooks]` badge |
 | 12.4 | `cat ~/.claude/settings.json 2>/dev/null \| jq '.hooks // empty'` | No hooks key (skipped without flag) |
 | 12.5 | `weave remove e2e-hooks-test` | Clean removal |
@@ -272,26 +272,25 @@ X-Test = "static-value"
 
 ---
 
-## Flow 10: Cleanup
+## Flow 14: Cleanup
 
 **Goal:** Restore machine to pre-test state.
 
 | Step | Command | Expected |
 |------|---------|----------|
-| 10.1 | `weave remove filesystem 2>/dev/null \|\| true` | Removed if present |
-| 10.2 | `weave remove github 2>/dev/null \|\| true` | Removed if present |
-| 10.3 | `weave remove e2e-local-test 2>/dev/null \|\| true` | Removed if present |
-| 10.4a | `weave remove e2e-hooks-test 2>/dev/null \|\| true` | Removed if present |
-| 10.4b | `weave remove e2e-http-test 2>/dev/null \|\| true` | Removed if present |
-| 10.4c | `weave remove tap-test 2>/dev/null \|\| true` | Removed if present |
-| 10.4d | `weave tap remove PackWeave/example-tap 2>/dev/null \|\| true` | Tap removed |
-| 10.4 | `weave use default` | Switch to default profile |
-| 10.5 | `weave profile delete e2e-validation 2>/dev/null \|\| true` | Profile removed |
-| 10.6 | `rm -rf /tmp/weave-e2e-local` | Directory removed |
-| 10.6a | `rm -rf /tmp/weave-e2e-hooks /tmp/weave-e2e-http` | Temp dirs removed |
-| 10.7 | `rm -f .mcp.json` | Project-scope file removed if present |
-| 10.8 | `weave list` | Clean — no e2e test packs |
-| 10.9 | `weave diagnose` | No errors |
+| 14.1 | `weave remove filesystem 2>/dev/null \|\| true` | Removed if present |
+| 14.2 | `weave remove github 2>/dev/null \|\| true` | Removed if present |
+| 14.3 | `weave remove e2e-local-test 2>/dev/null \|\| true` | Removed if present |
+| 14.4 | `weave remove e2e-hooks-test 2>/dev/null \|\| true` | Removed if present |
+| 14.5 | `weave remove e2e-http-test 2>/dev/null \|\| true` | Removed if present |
+| 14.6 | `weave remove tap-test 2>/dev/null \|\| true` | Removed if present |
+| 14.7 | `weave tap remove PackWeave/example-tap 2>/dev/null \|\| true` | Tap removed |
+| 14.8 | `weave use default` | Switch to default profile |
+| 14.9 | `weave profile delete e2e-validation 2>/dev/null \|\| true` | Profile removed |
+| 14.10 | `rm -rf /tmp/weave-e2e-local /tmp/weave-e2e-hooks /tmp/weave-e2e-http` | Temp dirs removed |
+| 14.11 | `rm -f .mcp.json` | Project-scope file removed if present |
+| 14.12 | `weave list` | Clean — no e2e test packs |
+| 14.13 | `weave diagnose` | No errors |
 
 **Pass criteria:** Machine state matches pre-test baseline.
 
@@ -313,4 +312,4 @@ X-Test = "static-value"
 | 11 — Community taps | ✓ / ✗ | |
 | 12 — Hooks | ✓ / ✗ | |
 | 13 — HTTP transport | ✓ / ✗ | |
-| 10 — Cleanup | ✓ / ✗ | |
+| 14 — Cleanup | ✓ / ✗ | |


### PR DESCRIPTION
## Summary
- Added 3 new flows to the manual E2E validation checklist
- Updated SKILL.md with new argument mappings

### New flows
- **Flow 11: Community taps** — tap add/list/remove lifecycle against `PackWeave/example-tap`
- **Flow 12: Hooks** — `--allow-hooks` opt-in, `[hooks]` badge, application, cleanup
- **Flow 13: HTTP transport** — remote MCP server with url/headers in CLI configs

### Updated
- **Flow 10 (Cleanup)** — added cleanup for hooks, HTTP, and tap test artifacts
- **SKILL.md** — added `tap`, `hooks`, `http` argument mappings, updated to 13 flows

## Test plan
- [x] Docs-only change — no code modified
- [x] Checklist format consistent with existing flows

**Note:** Flow 11 (taps) requires `PackWeave/example-tap` GitHub repo as a prerequisite.