### PR TITLE
docs: restructure M5/M6 roadmap for first public release

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,7 +121,7 @@ The milestones below are sequential. Each one produces something usable before t
 - [ ] Template management for CLI prompt files — CLAUDE.md, AGENTS.md, etc. (issue #50)
 - [ ] Pack-defined health checks in `weave diagnose` (issue #163)
 - [ ] Post-install scripts — `[scripts]` table in pack.toml (issue #167)
-- [ ] SHA-256 script integrity verification — hash hook commands at install, verify at sync/use (issue #168)
+- [ ] Pack content checksums in registry for integrity verification (issue #175)
 - [ ] Auto-update mechanism (issue #51)
 
 ### Housekeeping


### PR DESCRIPTION
## Summary

- **M5 trimmed from 25 → 11 issues** focused on what makes v0.4 a credible first public release
- **M6 created with 17 issues** for post-launch ecosystem depth (export, adapter modernization, authoring tools)
- **Plugin system (#52) and org sharing (#53) moved to explicitly deferred** — no demand signal
- **Roadmap restructured** with grouped themes per milestone (Ecosystem, Correctness & Security, Library Quality, Release Infrastructure)

### M5 (v0.4) — First Public Release
| Category | Issues |
|----------|--------|
| Ecosystem | #146 publish, #147 auth |
| Correctness & Security | #145 hook merge, #133 path normalization, #141 header validation |
| Library Quality | #143 WeaveError, #106 colorize |
| Release Infrastructure | #43 Release Please, #78 crates.io, #93 E2E validation, #92 cut release |

### M6 (v0.5) — Ecosystem Depth
Onboarding (#162 export, #165 placeholders, #161 prerequisites, #166 dry-run), adapter modernization (#61 skills, #62 rules, #60 project prompts, #170 skill dirs), ecosystem power features (#50 templates, #163 health checks, #167 post-install, #168 integrity, #51 auto-update).

## Test plan
- [x] Verify ROADMAP.md renders correctly on GitHub
- [x] Verify all issue references link to the correct issues