### PR TITLE
feat(release): auto-update Homebrew formula on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install cross
         if: matrix.use_cross
-        run: cargo install cross --locked
+        run: command -v cross || cargo install cross --locked
 
       - name: Build release binary
         run: |


### PR DESCRIPTION
## Summary

- Adds a `homebrew` job to the release workflow
- After the GitHub Release is published, it downloads the source tarball, computes SHA256, and pushes an updated formula to `PackWeave/homebrew-tap`
- Uses `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT scoped to homebrew-tap repo)

## How it works

```
v* tag push → build → release (GitHub Release) → homebrew (update formula)
                                                → publish (crates.io)
```

## Test plan

- [ ] CI passes
- [ ] After merge, next release tag triggers the homebrew job