### PR TITLE
fix: move .claude/worktrees/ under its own comment in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ target
 .claude/.packweave_manifest.json
 .mcp.json
 
+# Claude Code agent worktrees
+.claude/worktrees/
+
 # macOS metadata
 .DS_Store
-.claude/worktrees/


### PR DESCRIPTION
## Summary
- Moves `.claude/worktrees/` from being orphaned under `# macOS metadata` to its own `# Claude Code agent worktrees` comment section

## Test plan
- Visual inspection of `.gitignore`