### PR TITLE
fix(release): make workflow_dispatch tag optional and pass explicit tag_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v0.4.2)'
-        required: true
+        description: 'Tag to release (e.g., v0.4.2). Uses --ref tag if omitted.'
+        required: false
 
 permissions:
   contents: read   # default for all jobs; release job overrides to write
@@ -115,6 +115,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: |
             *.tar.gz
             *.tar.gz.sha256


### PR DESCRIPTION
## Summary

- Make `tag` input optional in workflow_dispatch — `gh workflow run release.yml --ref v0.4.2` now works
- Pass explicit `tag_name` to `softprops/action-gh-release` so manual triggers publish to the correct release

Addresses Copilot review comments on PR #209.

## Test plan

- [ ] After merge: `gh workflow run release.yml --ref v0.4.2` triggers release build