### PR TITLE
feat(core): add schema versioning to pack.toml, manifests, and lockfile

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -560,6 +560,29 @@ Panics are not used for recoverable errors. `unwrap()` and `expect()` are only a
 
 -----
 
+## Schema versioning
+
+Every persisted file format carries a `schema_version` integer field. This enables forward-compatible rejection: if a file was written by a newer weave version with a schema the current build does not understand, weave refuses to load it with a clear "please upgrade" error rather than silently misinterpreting the data.
+
+**Versioned formats:**
+
+| File | Constant | Location |
+|------|----------|----------|
+| `pack.toml` | `CURRENT_PACK_SCHEMA_VERSION` | `core/pack.rs` |
+| Profile lock files (`*.lock`) | `CURRENT_LOCKFILE_SCHEMA_VERSION` | `core/lockfile.rs` |
+| Registry `index.json` | `CURRENT_REGISTRY_SCHEMA_VERSION` | `core/registry.rs` |
+| Registry `packs/{name}.json` | `CURRENT_REGISTRY_SCHEMA_VERSION` | `core/registry.rs` |
+| Adapter tracking files (`.packweave_manifest.json`) | `CURRENT_MANIFEST_SCHEMA_VERSION` | `adapters/mod.rs` |
+
+**Rules:**
+
+1. **Default is 1.** When `schema_version` is absent, serde defaults it to `1`. This provides backward compatibility with files written before versioning was added.
+2. **Reject, never guess.** If `schema_version > CURRENT_*_SCHEMA_VERSION`, the load function returns `WeaveError::SchemaVersionTooNew`. No fallback parsing is attempted.
+3. **Bump the constant, not the code.** When a format change ships, bump the relevant `CURRENT_*` constant. Older clients will reject the new format automatically.
+4. **Registry index supports two shapes.** The `index.json` file accepts both a versioned envelope (`{"schema_version": N, "packs": {…}}`) and the legacy flat format (`{"pack-name": {…}, …}`) for backward compatibility with older registries and taps.
+
+-----
+
 ## Testing strategy
 
 - **Unit tests** live alongside the module they test (`#[cfg(test)]` blocks).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -110,7 +110,7 @@ The milestones below are sequential. Each one produces something usable before t
 - [ ] Enforce `min_tool_version` check during pack install (issue #197)
 - [ ] Switch Codex adapter to `toml_edit` to preserve user comments (issue #212)
 - [ ] Rollback on partial adapter apply failure — don't record install if any adapter fails (issue #221)
-- [ ] Schema versioning for pack.toml and sidecar manifests — graceful rejection of newer formats (issue #224)
+- [x] Schema versioning for pack.toml and sidecar manifests — graceful rejection of newer formats (issue #224)
 
 ### Adoption Accelerators
 

--- a/pack.schema.toml
+++ b/pack.schema.toml
@@ -7,6 +7,10 @@
 # This is not a functional file — it's documentation.
 # Generate a real pack.toml with: weave init
 
+# Schema version of this file format. Defaults to 1 if omitted.
+# Older weave versions will reject manifests with a version they don't support.
+schema_version = 1
+
 # ─────────────────────────────────────────────
 # [pack] — required
 # Core metadata about the pack.

--- a/pack.schema.toml
+++ b/pack.schema.toml
@@ -8,7 +8,7 @@
 # Generate a real pack.toml with: weave init
 
 # Schema version of this file format. Defaults to 1 if omitted.
-# Older weave versions will reject manifests with a version they don't support.
+# Older weave versions will reject pack.toml files with a version they don't support.
 schema_version = 1
 
 # ─────────────────────────────────────────────

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -3,7 +3,10 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::adapters::{ApplyOptions, CliAdapter, DiagnosticIssue, Severity};
+use crate::adapters::{
+    ApplyOptions, CURRENT_MANIFEST_SCHEMA_VERSION, CliAdapter, DiagnosticIssue, Severity,
+    default_manifest_schema_version,
+};
 use crate::core::pack::{McpServer, ResolvedPack, Transport};
 use crate::core::store::Store;
 use crate::error::{Result, WeaveError};
@@ -20,8 +23,10 @@ struct SettingsRecord {
 }
 
 /// Sidecar manifest tracking what weave wrote to Claude Code config.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct PackweaveManifest {
+    #[serde(default = "default_manifest_schema_version")]
+    schema_version: u32,
     #[serde(default)]
     servers: HashMap<String, String>, // server_name -> pack_name
     #[serde(default)]
@@ -39,6 +44,20 @@ struct PackweaveManifest {
     /// state regardless of the current working directory.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     project_dirs: HashMap<String, Vec<String>>, // pack_name -> [project_root_abs_paths]
+}
+
+impl Default for PackweaveManifest {
+    fn default() -> Self {
+        Self {
+            schema_version: CURRENT_MANIFEST_SCHEMA_VERSION,
+            servers: HashMap::new(),
+            commands: HashMap::new(),
+            prompt_blocks: Vec::new(),
+            settings: HashMap::new(),
+            hooks: Vec::new(),
+            project_dirs: HashMap::new(),
+        }
+    }
 }
 
 pub struct ClaudeCodeAdapter {
@@ -190,7 +209,20 @@ impl ClaudeCodeAdapter {
             return Ok(PackweaveManifest::default());
         }
         let content = util::read_file(&path)?;
-        serde_json::from_str(&content).map_err(|e| WeaveError::Json { path, source: e })
+        let manifest: PackweaveManifest =
+            serde_json::from_str(&content).map_err(|e| WeaveError::Json {
+                path: path.clone(),
+                source: e,
+            })?;
+        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "sidecar manifest",
+                path,
+                found: manifest.schema_version,
+                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+            });
+        }
+        Ok(manifest)
     }
 
     fn save_manifest(&self, manifest: &PackweaveManifest) -> Result<()> {
@@ -207,7 +239,20 @@ impl ClaudeCodeAdapter {
             return Ok(PackweaveManifest::default());
         }
         let content = util::read_file(&path)?;
-        serde_json::from_str(&content).map_err(|e| WeaveError::Json { path, source: e })
+        let manifest: PackweaveManifest =
+            serde_json::from_str(&content).map_err(|e| WeaveError::Json {
+                path: path.clone(),
+                source: e,
+            })?;
+        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "sidecar manifest",
+                path,
+                found: manifest.schema_version,
+                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+            });
+        }
+        Ok(manifest)
     }
 
     fn save_project_manifest(&self, manifest: &PackweaveManifest) -> Result<()> {
@@ -2183,5 +2228,35 @@ mod tests {
             manifest.project_dirs.contains_key("prompt-pack"),
             "project root should be retained when CLAUDE.md has orphaned prompt blocks"
         );
+    }
+
+    #[test]
+    fn reject_manifest_with_future_schema_version() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+
+        // Write a manifest with a future schema version.
+        let manifest_path = home.join(".claude/.packweave_manifest.json");
+        std::fs::write(
+            &manifest_path,
+            r#"{"schema_version": 99, "servers": {}, "commands": {}}"#,
+        )
+        .unwrap();
+
+        let adapter = test_adapter_with_home(&home);
+        let result = adapter.load_manifest();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("schema version 99"),
+            "expected 'schema version 99' in error: {msg}"
+        );
+    }
+
+    fn test_adapter_with_home(home: &std::path::Path) -> ClaudeCodeAdapter {
+        let no_project = home.join("no-project");
+        std::fs::create_dir_all(&no_project).unwrap();
+        ClaudeCodeAdapter::with_home_and_project(home.to_path_buf(), no_project)
     }
 }

--- a/src/adapters/claude_code.rs
+++ b/src/adapters/claude_code.rs
@@ -214,14 +214,11 @@ impl ClaudeCodeAdapter {
                 path: path.clone(),
                 source: e,
             })?;
-        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
-            return Err(WeaveError::SchemaVersionTooNew {
-                file_kind: "sidecar manifest",
-                path,
-                found: manifest.schema_version,
-                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
-            });
-        }
+        super::check_manifest_schema_version(
+            manifest.schema_version,
+            "Claude Code tracking file",
+            path,
+        )?;
         Ok(manifest)
     }
 
@@ -244,14 +241,11 @@ impl ClaudeCodeAdapter {
                 path: path.clone(),
                 source: e,
             })?;
-        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
-            return Err(WeaveError::SchemaVersionTooNew {
-                file_kind: "sidecar manifest",
-                path,
-                found: manifest.schema_version,
-                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
-            });
-        }
+        super::check_manifest_schema_version(
+            manifest.schema_version,
+            "Claude Code tracking file",
+            path,
+        )?;
         Ok(manifest)
     }
 

--- a/src/adapters/codex_cli.rs
+++ b/src/adapters/codex_cli.rs
@@ -4,7 +4,10 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use toml_edit::DocumentMut;
 
-use crate::adapters::{ApplyOptions, CliAdapter, DiagnosticIssue, Severity};
+use crate::adapters::{
+    ApplyOptions, CURRENT_MANIFEST_SCHEMA_VERSION, CliAdapter, DiagnosticIssue, Severity,
+    default_manifest_schema_version,
+};
 use crate::core::pack::{McpServer, PackSource, ResolvedPack, Transport};
 use crate::core::store::Store;
 use crate::error::{Result, WeaveError};
@@ -22,8 +25,10 @@ struct SettingsRecord {
 }
 
 /// Sidecar manifest tracking what weave wrote to Codex CLI config.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct CodexManifest {
+    #[serde(default = "default_manifest_schema_version")]
+    schema_version: u32,
     #[serde(default)]
     servers: HashMap<String, String>, // server_name -> pack_name
     #[serde(default)]
@@ -32,6 +37,18 @@ struct CodexManifest {
     settings: HashMap<String, SettingsRecord>, // pack_name -> settings record
     #[serde(default)]
     skills: HashMap<String, String>, // filename -> pack_name
+}
+
+impl Default for CodexManifest {
+    fn default() -> Self {
+        Self {
+            schema_version: CURRENT_MANIFEST_SCHEMA_VERSION,
+            servers: HashMap::new(),
+            prompt_blocks: Vec::new(),
+            settings: HashMap::new(),
+            skills: HashMap::new(),
+        }
+    }
 }
 
 pub struct CodexAdapter {
@@ -124,7 +141,20 @@ impl CodexAdapter {
             return Ok(CodexManifest::default());
         }
         let content = util::read_file(&path)?;
-        serde_json::from_str(&content).map_err(|e| WeaveError::Json { path, source: e })
+        let manifest: CodexManifest =
+            serde_json::from_str(&content).map_err(|e| WeaveError::Json {
+                path: path.clone(),
+                source: e,
+            })?;
+        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "sidecar manifest",
+                path,
+                found: manifest.schema_version,
+                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+            });
+        }
+        Ok(manifest)
     }
 
     fn save_manifest(&self, manifest: &CodexManifest) -> Result<()> {
@@ -141,7 +171,20 @@ impl CodexAdapter {
             return Ok(CodexManifest::default());
         }
         let content = util::read_file(&path)?;
-        serde_json::from_str(&content).map_err(|e| WeaveError::Json { path, source: e })
+        let manifest: CodexManifest =
+            serde_json::from_str(&content).map_err(|e| WeaveError::Json {
+                path: path.clone(),
+                source: e,
+            })?;
+        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "sidecar manifest",
+                path,
+                found: manifest.schema_version,
+                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+            });
+        }
+        Ok(manifest)
     }
 
     fn save_project_manifest(&self, manifest: &CodexManifest) -> Result<()> {
@@ -1272,4 +1315,31 @@ fn which_exists(cmd: &str) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn reject_manifest_with_future_schema_version() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_path_buf();
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+
+        let manifest_path = home.join(".codex/.packweave_manifest.json");
+        std::fs::write(&manifest_path, r#"{"schema_version": 99, "servers": {}}"#).unwrap();
+
+        let no_project = home.join("no-project");
+        std::fs::create_dir_all(&no_project).unwrap();
+        let adapter = CodexAdapter::with_home_and_project(home, no_project);
+        let result = adapter.load_manifest();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("schema version 99"),
+            "expected 'schema version 99' in error: {msg}"
+        );
+    }
 }

--- a/src/adapters/codex_cli.rs
+++ b/src/adapters/codex_cli.rs
@@ -146,14 +146,11 @@ impl CodexAdapter {
                 path: path.clone(),
                 source: e,
             })?;
-        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
-            return Err(WeaveError::SchemaVersionTooNew {
-                file_kind: "sidecar manifest",
-                path,
-                found: manifest.schema_version,
-                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
-            });
-        }
+        super::check_manifest_schema_version(
+            manifest.schema_version,
+            "Codex CLI tracking file",
+            path,
+        )?;
         Ok(manifest)
     }
 
@@ -176,14 +173,11 @@ impl CodexAdapter {
                 path: path.clone(),
                 source: e,
             })?;
-        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
-            return Err(WeaveError::SchemaVersionTooNew {
-                file_kind: "sidecar manifest",
-                path,
-                found: manifest.schema_version,
-                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
-            });
-        }
+        super::check_manifest_schema_version(
+            manifest.schema_version,
+            "Codex CLI tracking file",
+            path,
+        )?;
         Ok(manifest)
     }
 

--- a/src/adapters/gemini_cli.rs
+++ b/src/adapters/gemini_cli.rs
@@ -128,14 +128,11 @@ impl GeminiCliAdapter {
                 path: path.clone(),
                 source: e,
             })?;
-        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
-            return Err(WeaveError::SchemaVersionTooNew {
-                file_kind: "sidecar manifest",
-                path,
-                found: manifest.schema_version,
-                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
-            });
-        }
+        super::check_manifest_schema_version(
+            manifest.schema_version,
+            "Gemini CLI tracking file",
+            path,
+        )?;
         Ok(manifest)
     }
 
@@ -158,14 +155,11 @@ impl GeminiCliAdapter {
                 path: path.clone(),
                 source: e,
             })?;
-        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
-            return Err(WeaveError::SchemaVersionTooNew {
-                file_kind: "sidecar manifest",
-                path,
-                found: manifest.schema_version,
-                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
-            });
-        }
+        super::check_manifest_schema_version(
+            manifest.schema_version,
+            "Gemini CLI tracking file",
+            path,
+        )?;
         Ok(manifest)
     }
 

--- a/src/adapters/gemini_cli.rs
+++ b/src/adapters/gemini_cli.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::adapters::{ApplyOptions, CliAdapter, DiagnosticIssue, Severity};
+use crate::adapters::{
+    ApplyOptions, CURRENT_MANIFEST_SCHEMA_VERSION, CliAdapter, DiagnosticIssue, Severity,
+    default_manifest_schema_version,
+};
 use crate::core::pack::{McpServer, ResolvedPack, Transport};
 use crate::core::store::Store;
 use crate::error::{Result, WeaveError};
@@ -17,14 +20,27 @@ struct SettingsRecord {
 }
 
 /// Sidecar manifest tracking what weave wrote to Gemini CLI config.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct GeminiManifest {
+    #[serde(default = "default_manifest_schema_version")]
+    schema_version: u32,
     #[serde(default)]
     servers: HashMap<String, String>, // server_name -> pack_name
     #[serde(default)]
     prompt_blocks: Vec<String>,
     #[serde(default)]
     settings: HashMap<String, SettingsRecord>, // pack_name -> settings record
+}
+
+impl Default for GeminiManifest {
+    fn default() -> Self {
+        Self {
+            schema_version: CURRENT_MANIFEST_SCHEMA_VERSION,
+            servers: HashMap::new(),
+            prompt_blocks: Vec::new(),
+            settings: HashMap::new(),
+        }
+    }
 }
 
 pub struct GeminiCliAdapter {
@@ -107,7 +123,20 @@ impl GeminiCliAdapter {
             return Ok(GeminiManifest::default());
         }
         let content = util::read_file(&path)?;
-        serde_json::from_str(&content).map_err(|e| WeaveError::Json { path, source: e })
+        let manifest: GeminiManifest =
+            serde_json::from_str(&content).map_err(|e| WeaveError::Json {
+                path: path.clone(),
+                source: e,
+            })?;
+        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "sidecar manifest",
+                path,
+                found: manifest.schema_version,
+                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+            });
+        }
+        Ok(manifest)
     }
 
     fn save_manifest(&self, manifest: &GeminiManifest) -> Result<()> {
@@ -124,7 +153,20 @@ impl GeminiCliAdapter {
             return Ok(GeminiManifest::default());
         }
         let content = util::read_file(&path)?;
-        serde_json::from_str(&content).map_err(|e| WeaveError::Json { path, source: e })
+        let manifest: GeminiManifest =
+            serde_json::from_str(&content).map_err(|e| WeaveError::Json {
+                path: path.clone(),
+                source: e,
+            })?;
+        if manifest.schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "sidecar manifest",
+                path,
+                found: manifest.schema_version,
+                supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+            });
+        }
+        Ok(manifest)
     }
 
     fn save_project_manifest(&self, manifest: &GeminiManifest) -> Result<()> {
@@ -1258,6 +1300,27 @@ mod tests {
         assert!(
             content["mcpServers"]["test-server"].get("env").is_none(),
             "env key should not be present when server has no env vars"
+        );
+    }
+
+    #[test]
+    fn reject_manifest_with_future_schema_version() {
+        let dir = TempDir::new().unwrap();
+        let home = dir.path().to_path_buf();
+        std::fs::create_dir_all(home.join(".gemini")).unwrap();
+
+        let manifest_path = home.join(".gemini/.packweave_manifest.json");
+        std::fs::write(&manifest_path, r#"{"schema_version": 99, "servers": {}}"#).unwrap();
+
+        let no_project = home.join("no-project");
+        std::fs::create_dir_all(&no_project).unwrap();
+        let adapter = GeminiCliAdapter::with_home_and_project(home, no_project);
+        let result = adapter.load_manifest();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("schema version 99"),
+            "expected 'schema version 99' in error: {msg}"
         );
     }
 }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -10,6 +10,14 @@ use serde::Serialize;
 use crate::core::pack::ResolvedPack;
 use crate::error::Result;
 
+/// Current schema version for adapter sidecar manifest files.
+pub const CURRENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// Default schema version for serde deserialization of adapter manifests.
+pub(crate) fn default_manifest_schema_version() -> u32 {
+    1
+}
+
 /// Options passed to [`CliAdapter::apply`] controlling optional behaviours.
 #[derive(Debug, Clone, Default)]
 pub struct ApplyOptions {

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -13,9 +13,30 @@ use crate::error::Result;
 /// Current schema version for adapter sidecar manifest files.
 pub const CURRENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
 
-/// Default schema version for serde deserialization of adapter manifests.
+/// Serde default for manifests that predate schema versioning — always returns 1
+/// (the original schema), not `CURRENT_MANIFEST_SCHEMA_VERSION`. Files that omit
+/// the field were written before versioning existed and are implicitly version 1.
 pub(crate) fn default_manifest_schema_version() -> u32 {
     1
+}
+
+/// Check that a deserialized manifest's schema version is supported by this build.
+/// Returns `SchemaVersionTooNew` if the manifest was written by a newer weave version.
+pub(crate) fn check_manifest_schema_version(
+    schema_version: u32,
+    file_kind: &'static str,
+    path: std::path::PathBuf,
+) -> crate::error::Result<()> {
+    if schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+        return Err(crate::error::WeaveError::SchemaVersionTooNew {
+            file_kind,
+            path,
+            found: schema_version,
+            supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+            current_version: env!("CARGO_PKG_VERSION"),
+        });
+    }
+    Ok(())
 }
 
 /// Options passed to [`CliAdapter::apply`] controlling optional behaviours.

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -27,7 +27,7 @@ pub(crate) fn check_manifest_schema_version(
     file_kind: &'static str,
     path: std::path::PathBuf,
 ) -> crate::error::Result<()> {
-    if schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
+    if schema_version == 0 || schema_version > CURRENT_MANIFEST_SCHEMA_VERSION {
         return Err(crate::error::WeaveError::SchemaVersionTooNew {
             file_kind,
             path,

--- a/src/cli/diagnose.rs
+++ b/src/cli/diagnose.rs
@@ -91,13 +91,30 @@ pub fn build_report(
     for adapter in adapters {
         let installed = adapter.is_installed();
         let (issues, tracked) = if installed {
-            let issues = adapter
-                .diagnose()
-                .with_context(|| format!("diagnosing {}", adapter.name()))?;
-            let tracked = adapter
-                .tracked_packs()
-                .with_context(|| format!("listing tracked packs for {}", adapter.name()))?;
-            (issues, tracked)
+            // Gracefully degrade when the adapter's tracking file uses a future
+            // schema version: report it as a diagnostic error instead of aborting
+            // the entire diagnose command.
+            match adapter.diagnose() {
+                Ok(issues) => {
+                    let tracked = adapter.tracked_packs().unwrap_or_default();
+                    (issues, tracked)
+                }
+                Err(crate::error::WeaveError::SchemaVersionTooNew { .. }) => {
+                    let issues = vec![DiagnosticIssue {
+                        severity: crate::adapters::Severity::Error,
+                        message: format!(
+                            "{} tracking file uses a newer schema version — upgrade weave to manage this adapter",
+                            adapter.name()
+                        ),
+                        suggestion: Some("run: cargo install packweave".to_string()),
+                        pack: None,
+                    }];
+                    (issues, std::collections::HashSet::new())
+                }
+                Err(e) => {
+                    return Err(e).context(format!("diagnosing {}", adapter.name()));
+                }
+            }
         } else {
             (Vec::new(), std::collections::HashSet::new())
         };

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -43,8 +43,9 @@ fn validate_pack_name(name: &str) -> Result<()> {
 
 /// Generate the `pack.toml` content for a new pack.
 fn pack_toml_content(name: &str) -> String {
+    let sv = crate::core::pack::CURRENT_PACK_SCHEMA_VERSION;
     format!(
-        r#"schema_version = 1
+        r#"schema_version = {sv}
 
 [pack]
 name = "{name}"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -44,7 +44,9 @@ fn validate_pack_name(name: &str) -> Result<()> {
 /// Generate the `pack.toml` content for a new pack.
 fn pack_toml_content(name: &str) -> String {
     format!(
-        r#"[pack]
+        r#"schema_version = 1
+
+[pack]
 name = "{name}"
 version = "0.1.0"
 description = "TODO: describe what this pack does"

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -147,6 +147,7 @@ mod tests {
         // Constructing an empty lock file and verifying it has no packs
         // is the unit-testable core of the "sync with nothing locked" path.
         let lockfile = LockFile {
+            schema_version: crate::core::lockfile::CURRENT_LOCKFILE_SCHEMA_VERSION,
             packs: BTreeMap::new(),
         };
         assert!(

--- a/src/core/lockfile.rs
+++ b/src/core/lockfile.rs
@@ -10,6 +10,9 @@ use crate::util;
 /// Current schema version for lock files.
 pub const CURRENT_LOCKFILE_SCHEMA_VERSION: u32 = 1;
 
+/// Serde default for lock files that predate schema versioning — always returns 1
+/// (the original schema), not `CURRENT_LOCKFILE_SCHEMA_VERSION`. Files that omit
+/// the field were written before versioning existed and are implicitly version 1.
 fn default_schema_version() -> u32 {
     1
 }
@@ -18,6 +21,7 @@ fn default_schema_version() -> u32 {
 /// Stored at `~/.packweave/locks/<profile>.lock`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LockFile {
+    /// Lock file schema version. Defaults to 1 for files that predate versioning.
     #[serde(default = "default_schema_version")]
     pub schema_version: u32,
     #[serde(default)]
@@ -63,6 +67,7 @@ impl LockFile {
                 path,
                 found: lockfile.schema_version,
                 supported: CURRENT_LOCKFILE_SCHEMA_VERSION,
+                current_version: env!("CARGO_PKG_VERSION"),
             });
         }
         Ok(lockfile)
@@ -161,8 +166,39 @@ mod tests {
         let toml_str = "schema_version = 99\n\n[packs.test]\nversion = \"1.0.0\"\n";
         let parsed: LockFile = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed.schema_version, 99);
-        // The version check happens in LockFile::load() which reads from disk,
-        // so we verify the field deserializes correctly and test the guard directly.
         assert!(parsed.schema_version > CURRENT_LOCKFILE_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn load_rejects_future_schema_version() {
+        // Write a lockfile with a future schema version to a temp dir and verify
+        // that LockFile::load() returns SchemaVersionTooNew (not just deserialization).
+        let tmp = tempfile::tempdir().unwrap();
+        let locks_dir = tmp.path().join("locks");
+        std::fs::create_dir_all(&locks_dir).unwrap();
+        let lock_path = locks_dir.join("test-profile.lock");
+        std::fs::write(
+            &lock_path,
+            "schema_version = 99\n\n[packs.test]\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        // Temporarily override the packweave dir so load() finds our temp lockfile.
+        // LockFile::load uses util::packweave_dir() which reads WEAVE_TEST_STORE_DIR.
+        // SAFETY: This test runs single-threaded and restores the var immediately.
+        unsafe { std::env::set_var("WEAVE_TEST_STORE_DIR", tmp.path()) };
+        let result = LockFile::load("test-profile");
+        unsafe { std::env::remove_var("WEAVE_TEST_STORE_DIR") };
+
+        let err = result.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("schema version 99"),
+            "expected SchemaVersionTooNew, got: {msg}"
+        );
+        assert!(
+            msg.contains("please upgrade"),
+            "expected upgrade hint, got: {msg}"
+        );
     }
 }

--- a/src/core/lockfile.rs
+++ b/src/core/lockfile.rs
@@ -7,10 +7,19 @@ use crate::core::pack::PackSource;
 use crate::error::{Result, WeaveError};
 use crate::util;
 
+/// Current schema version for lock files.
+pub const CURRENT_LOCKFILE_SCHEMA_VERSION: u32 = 1;
+
+fn default_schema_version() -> u32 {
+    1
+}
+
 /// Lock file pinning exact resolved versions for a profile.
 /// Stored at `~/.packweave/locks/<profile>.lock`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LockFile {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
     #[serde(default)]
     pub packs: BTreeMap<String, LockedPack>,
 }
@@ -39,14 +48,24 @@ impl LockFile {
         let path = Self::path(profile_name)?;
         if !path.exists() {
             return Ok(Self {
+                schema_version: CURRENT_LOCKFILE_SCHEMA_VERSION,
                 packs: BTreeMap::new(),
             });
         }
         let content = util::read_file(&path)?;
-        toml::from_str(&content).map_err(|e| WeaveError::Toml {
-            path,
+        let lockfile: LockFile = toml::from_str(&content).map_err(|e| WeaveError::Toml {
+            path: path.clone(),
             source: Box::new(e),
-        })
+        })?;
+        if lockfile.schema_version > CURRENT_LOCKFILE_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "lock file",
+                path,
+                found: lockfile.schema_version,
+                supported: CURRENT_LOCKFILE_SCHEMA_VERSION,
+            });
+        }
+        Ok(lockfile)
     }
 
     /// Save this lock file to disk.
@@ -81,6 +100,7 @@ mod tests {
     #[test]
     fn lock_and_unlock() {
         let mut lock = LockFile {
+            schema_version: CURRENT_LOCKFILE_SCHEMA_VERSION,
             packs: BTreeMap::new(),
         };
 
@@ -104,6 +124,7 @@ mod tests {
     #[test]
     fn roundtrip_toml() {
         let mut lock = LockFile {
+            schema_version: CURRENT_LOCKFILE_SCHEMA_VERSION,
             packs: BTreeMap::new(),
         };
         lock.lock_pack(
@@ -133,5 +154,15 @@ mod tests {
             semver::Version::new(0, 1, 0)
         );
         assert!(parsed.packs["filesystem"].source.is_none());
+    }
+
+    #[test]
+    fn reject_lockfile_with_future_schema_version() {
+        let toml_str = "schema_version = 99\n\n[packs.test]\nversion = \"1.0.0\"\n";
+        let parsed: LockFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.schema_version, 99);
+        // The version check happens in LockFile::load() which reads from disk,
+        // so we verify the field deserializes correctly and test the guard directly.
+        assert!(parsed.schema_version > CURRENT_LOCKFILE_SCHEMA_VERSION);
     }
 }

--- a/src/core/lockfile.rs
+++ b/src/core/lockfile.rs
@@ -61,7 +61,8 @@ impl LockFile {
             path: path.clone(),
             source: Box::new(e),
         })?;
-        if lockfile.schema_version > CURRENT_LOCKFILE_SCHEMA_VERSION {
+        if lockfile.schema_version == 0 || lockfile.schema_version > CURRENT_LOCKFILE_SCHEMA_VERSION
+        {
             return Err(WeaveError::SchemaVersionTooNew {
                 file_kind: "lock file",
                 path,

--- a/src/core/pack.rs
+++ b/src/core/pack.rs
@@ -201,7 +201,7 @@ impl Pack {
             path: path.to_path_buf(),
             source: Box::new(e),
         })?;
-        if manifest.schema_version > CURRENT_PACK_SCHEMA_VERSION {
+        if manifest.schema_version == 0 || manifest.schema_version > CURRENT_PACK_SCHEMA_VERSION {
             return Err(WeaveError::SchemaVersionTooNew {
                 file_kind: "pack manifest",
                 path: path.to_path_buf(),

--- a/src/core/pack.rs
+++ b/src/core/pack.rs
@@ -8,6 +8,9 @@ use crate::error::{Result, WeaveError};
 /// Current schema version for `pack.toml` files.
 pub const CURRENT_PACK_SCHEMA_VERSION: u32 = 1;
 
+/// Serde default for pack manifests that predate schema versioning — always returns 1
+/// (the original schema), not `CURRENT_PACK_SCHEMA_VERSION`. Files that omit
+/// the field were written before versioning existed and are implicitly version 1.
 fn default_schema_version() -> u32 {
     1
 }
@@ -158,6 +161,7 @@ pub enum PackSource {
 /// Canonical nested format: metadata under a `[pack]` section.
 #[derive(Debug, Deserialize)]
 struct PackManifest {
+    /// Pack manifest schema version. Defaults to 1 for files that predate versioning.
     #[serde(default = "default_schema_version")]
     schema_version: u32,
     pack: PackMetadataToml,
@@ -203,6 +207,7 @@ impl Pack {
                 path: path.to_path_buf(),
                 found: manifest.schema_version,
                 supported: CURRENT_PACK_SCHEMA_VERSION,
+                current_version: env!("CARGO_PKG_VERSION"),
             });
         }
         let pack = Pack {
@@ -1095,8 +1100,8 @@ description = "Test"
             "expected 'schema version 99' in error: {msg}"
         );
         assert!(
-            msg.contains("please upgrade weave"),
-            "expected 'please upgrade weave' in error: {msg}"
+            msg.contains("please upgrade"),
+            "expected 'please upgrade' in error: {msg}"
         );
     }
 

--- a/src/core/pack.rs
+++ b/src/core/pack.rs
@@ -5,6 +5,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, WeaveError};
 
+/// Current schema version for `pack.toml` files.
+pub const CURRENT_PACK_SCHEMA_VERSION: u32 = 1;
+
+fn default_schema_version() -> u32 {
+    1
+}
+
 /// The in-memory representation of a parsed `pack.toml`.
 /// A `Pack` that exists is always structurally valid.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,6 +158,8 @@ pub enum PackSource {
 /// Canonical nested format: metadata under a `[pack]` section.
 #[derive(Debug, Deserialize)]
 struct PackManifest {
+    #[serde(default = "default_schema_version")]
+    schema_version: u32,
     pack: PackMetadataToml,
     #[serde(default)]
     servers: Option<Vec<McpServer>>,
@@ -188,6 +197,14 @@ impl Pack {
             path: path.to_path_buf(),
             source: Box::new(e),
         })?;
+        if manifest.schema_version > CURRENT_PACK_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "pack manifest",
+                path: path.to_path_buf(),
+                found: manifest.schema_version,
+                supported: CURRENT_PACK_SCHEMA_VERSION,
+            });
+        }
         let pack = Pack {
             name: manifest.pack.name,
             version: manifest.pack.version,
@@ -1041,6 +1058,60 @@ Authorization = "Bearer ${TOKEN}"
             result.is_ok(),
             "Authorization with Bearer ${{TOKEN}} should pass: {:?}",
             result.err()
+        );
+    }
+
+    // ── Schema versioning tests ──────────────────────────────────────
+
+    #[test]
+    fn parse_pack_with_explicit_schema_version_1() {
+        let toml = r#"
+schema_version = 1
+
+[pack]
+name = "test"
+version = "1.0.0"
+description = "Test"
+"#;
+        let result = Pack::from_toml(toml, &PathBuf::from("test.toml"));
+        assert!(result.is_ok(), "explicit schema_version = 1 should work");
+    }
+
+    #[test]
+    fn reject_pack_with_future_schema_version() {
+        let toml = r#"
+schema_version = 99
+
+[pack]
+name = "test"
+version = "1.0.0"
+description = "Test"
+"#;
+        let result = Pack::from_toml(toml, &PathBuf::from("test.toml"));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("schema version 99"),
+            "expected 'schema version 99' in error: {msg}"
+        );
+        assert!(
+            msg.contains("please upgrade weave"),
+            "expected 'please upgrade weave' in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_pack_without_schema_version_defaults_to_1() {
+        let toml = r#"
+[pack]
+name = "test"
+version = "1.0.0"
+description = "Test"
+"#;
+        let result = Pack::from_toml(toml, &PathBuf::from("test.toml"));
+        assert!(
+            result.is_ok(),
+            "missing schema_version should default to 1 and succeed"
         );
     }
 }

--- a/src/core/publish.rs
+++ b/src/core/publish.rs
@@ -604,6 +604,7 @@ mod tests {
         use crate::core::registry::{MockRegistry, PackMetadata, PackRelease};
         let mut registry = MockRegistry::new();
         registry.add_pack(PackMetadata {
+            schema_version: crate::core::registry::CURRENT_REGISTRY_SCHEMA_VERSION,
             name: "my-pack".into(),
             description: "test".into(),
             authors: vec![],
@@ -632,6 +633,7 @@ mod tests {
         use crate::core::registry::{MockRegistry, PackMetadata, PackRelease};
         let mut registry = MockRegistry::new();
         registry.add_pack(PackMetadata {
+            schema_version: crate::core::registry::CURRENT_REGISTRY_SCHEMA_VERSION,
             name: "my-pack".into(),
             description: "test".into(),
             authors: vec![],

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -4,6 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, WeaveError};
 
+/// Maximum registry schema version this build of weave can parse.
+/// Bump when a registry format change ships that older clients must reject.
+pub const CURRENT_REGISTRY_SCHEMA_VERSION: u32 = 1;
+
+fn default_registry_schema_version() -> u32 {
+    1
+}
+
 /// Summary of a pack in registry search results.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PackSummary {
@@ -18,6 +26,9 @@ pub struct PackSummary {
 /// Deserialized from `packs/{name}.json` in the sparse index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PackMetadata {
+    /// Registry schema version. Defaults to 1 for files that predate versioning.
+    #[serde(default = "default_registry_schema_version")]
+    pub schema_version: u32,
     pub name: String,
     pub description: String,
     #[serde(default)]
@@ -89,6 +100,16 @@ struct PackListing {
 /// The lightweight search index — a flat JSON object mapping pack names to their listing.
 type SearchIndex = HashMap<String, PackListing>;
 
+/// Versioned envelope for `index.json`. New registries emit this format.
+/// Older registries that predate schema versioning emit a flat `SearchIndex`
+/// (just the `packs` map at the top level, no wrapper).
+#[derive(Debug, Clone, Deserialize)]
+struct SearchIndexEnvelope {
+    #[allow(dead_code)]
+    schema_version: u32,
+    packs: SearchIndex,
+}
+
 /// GitHub-backed registry implementation using a two-tier sparse index.
 ///
 /// - `{base_url}/index.json` — lightweight catalog fetched once for search and listing
@@ -118,6 +139,10 @@ impl GitHubRegistry {
     }
 
     /// Fetch and cache the lightweight `index.json`.
+    ///
+    /// Supports two formats:
+    /// - **Envelope** (new): `{"schema_version": N, "packs": {…}}`
+    /// - **Flat** (legacy): `{"pack-name": {…}, …}` (no wrapper, defaults to schema v1)
     fn load_search_index(&self) -> Result<SearchIndex> {
         {
             let cache = self
@@ -130,8 +155,7 @@ impl GitHubRegistry {
         }
 
         let url = format!("{}/index.json", self.base_url);
-        let index: SearchIndex =
-            http_get_json(&url, "registry search index", self.token.as_deref())?;
+        let index = self.parse_search_index(&url)?;
 
         {
             let mut cache = self
@@ -141,6 +165,36 @@ impl GitHubRegistry {
             *cache = Some(index.clone());
         }
 
+        Ok(index)
+    }
+
+    /// Parse `index.json`, trying the versioned envelope first, then the legacy
+    /// flat format for backward compatibility with older registries and taps.
+    fn parse_search_index(&self, url: &str) -> Result<SearchIndex> {
+        let raw: serde_json::Value =
+            http_get_json(url, "registry search index", self.token.as_deref())?;
+
+        // Try the new envelope format first: {"schema_version": N, "packs": {…}}
+        if let Some(sv) = raw.get("schema_version").and_then(|v| v.as_u64()) {
+            let sv = sv as u32;
+            if sv > CURRENT_REGISTRY_SCHEMA_VERSION {
+                return Err(WeaveError::SchemaVersionTooNew {
+                    file_kind: "registry search index",
+                    path: url.into(),
+                    found: sv,
+                    supported: CURRENT_REGISTRY_SCHEMA_VERSION,
+                });
+            }
+            let envelope: SearchIndexEnvelope = serde_json::from_value(raw).map_err(|e| {
+                WeaveError::Registry(format!("failed to parse registry search index: {e}"))
+            })?;
+            return Ok(envelope.packs);
+        }
+
+        // Legacy flat format: the entire JSON object is the pack map.
+        let index: SearchIndex = serde_json::from_value(raw).map_err(|e| {
+            WeaveError::Registry(format!("failed to parse registry search index: {e}"))
+        })?;
         Ok(index)
     }
 
@@ -179,6 +233,15 @@ impl GitHubRegistry {
             },
             other => other,
         })?;
+
+        if meta.schema_version > CURRENT_REGISTRY_SCHEMA_VERSION {
+            return Err(WeaveError::SchemaVersionTooNew {
+                file_kind: "registry pack metadata",
+                path: url.into(),
+                found: meta.schema_version,
+                supported: CURRENT_REGISTRY_SCHEMA_VERSION,
+            });
+        }
 
         {
             let mut cache = self.cached_packs.lock().unwrap_or_else(|e| e.into_inner());
@@ -540,6 +603,7 @@ mod tests {
 
     fn sample_metadata() -> PackMetadata {
         PackMetadata {
+            schema_version: CURRENT_REGISTRY_SCHEMA_VERSION,
             name: "webdev".into(),
             description: "Web development tools".into(),
             authors: vec!["tester".into()],
@@ -623,6 +687,7 @@ mod tests {
 
     fn sample_metadata_named(name: &str, desc: &str) -> PackMetadata {
         PackMetadata {
+            schema_version: CURRENT_REGISTRY_SCHEMA_VERSION,
             name: name.into(),
             description: desc.into(),
             authors: vec!["tester".into()],
@@ -932,6 +997,7 @@ mod tests {
     #[test]
     fn latest_version_no_releases() {
         let meta = PackMetadata {
+            schema_version: CURRENT_REGISTRY_SCHEMA_VERSION,
             name: "empty".into(),
             description: "no releases".into(),
             authors: vec![],
@@ -1002,5 +1068,63 @@ mod tests {
         assert!(is_trusted(
             "https://RAW.GITHUBUSERCONTENT.COM/PackWeave/registry/main/index.json"
         ));
+    }
+
+    // ── Schema version tests ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_pack_metadata_without_schema_version_defaults_to_1() {
+        let json = r#"{
+            "name": "test",
+            "description": "test pack",
+            "versions": []
+        }"#;
+        let meta: PackMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.schema_version, 1);
+    }
+
+    #[test]
+    fn parse_pack_metadata_with_explicit_schema_version() {
+        let json = r#"{
+            "schema_version": 1,
+            "name": "test",
+            "description": "test pack",
+            "versions": []
+        }"#;
+        let meta: PackMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.schema_version, 1);
+    }
+
+    #[test]
+    fn parse_search_index_envelope_format() {
+        let json = r#"{
+            "schema_version": 1,
+            "packs": {
+                "test-pack": {
+                    "name": "test-pack",
+                    "description": "A test",
+                    "keywords": [],
+                    "latest_version": "0.1.0"
+                }
+            }
+        }"#;
+        let envelope: SearchIndexEnvelope = serde_json::from_str(json).unwrap();
+        assert_eq!(envelope.schema_version, 1);
+        assert!(envelope.packs.contains_key("test-pack"));
+    }
+
+    #[test]
+    fn parse_search_index_legacy_flat_format() {
+        let json = r#"{
+            "test-pack": {
+                "name": "test-pack",
+                "description": "A test",
+                "keywords": [],
+                "latest_version": "0.1.0"
+            }
+        }"#;
+        // Legacy format has no schema_version key, so it parses as a flat SearchIndex.
+        let index: SearchIndex = serde_json::from_str(json).unwrap();
+        assert!(index.contains_key("test-pack"));
     }
 }

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -186,7 +186,7 @@ impl GitHubRegistry {
         if let Some(sv) = raw.get("schema_version").and_then(|v| v.as_u64()) {
             // Treat any value that overflows u32 as "too new" rather than silently truncating.
             let sv = u32::try_from(sv).unwrap_or(u32::MAX);
-            if sv > CURRENT_REGISTRY_SCHEMA_VERSION {
+            if sv == 0 || sv > CURRENT_REGISTRY_SCHEMA_VERSION {
                 return Err(WeaveError::SchemaVersionTooNew {
                     file_kind: "registry search index",
                     path: url.into(),
@@ -244,7 +244,7 @@ impl GitHubRegistry {
             other => other,
         })?;
 
-        if meta.schema_version > CURRENT_REGISTRY_SCHEMA_VERSION {
+        if meta.schema_version == 0 || meta.schema_version > CURRENT_REGISTRY_SCHEMA_VERSION {
             return Err(WeaveError::SchemaVersionTooNew {
                 file_kind: "registry pack metadata",
                 path: url.into(),
@@ -1137,5 +1137,68 @@ mod tests {
         // Legacy format has no schema_version key, so it parses as a flat SearchIndex.
         let index: SearchIndex = serde_json::from_str(json).unwrap();
         assert!(index.contains_key("test-pack"));
+    }
+
+    #[test]
+    fn reject_pack_metadata_with_future_schema_version() {
+        // Simulate what load_pack_metadata does: deserialize then check.
+        let json = r#"{
+            "schema_version": 99,
+            "name": "test",
+            "description": "test pack",
+            "versions": []
+        }"#;
+        let meta: PackMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.schema_version, 99);
+        // The guard in load_pack_metadata would reject this:
+        assert!(meta.schema_version > CURRENT_REGISTRY_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn reject_pack_metadata_with_schema_version_zero() {
+        let json = r#"{
+            "schema_version": 0,
+            "name": "test",
+            "description": "test pack",
+            "versions": []
+        }"#;
+        let meta: PackMetadata = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.schema_version, 0);
+        // schema_version 0 is invalid — the guard rejects it.
+        assert!(meta.schema_version == 0);
+    }
+
+    #[test]
+    fn reject_search_index_envelope_with_future_schema_version() {
+        // Verify the version check logic: envelope with version 99 should be rejected.
+        let json = r#"{
+            "schema_version": 99,
+            "packs": {
+                "test-pack": {
+                    "name": "test-pack",
+                    "description": "A test",
+                    "keywords": [],
+                    "latest_version": "0.1.0"
+                }
+            }
+        }"#;
+        let raw: serde_json::Value = serde_json::from_str(json).unwrap();
+        let sv = raw.get("schema_version").and_then(|v| v.as_u64()).unwrap();
+        let sv = u32::try_from(sv).unwrap_or(u32::MAX);
+        assert!(
+            sv == 0 || sv > CURRENT_REGISTRY_SCHEMA_VERSION,
+            "version {sv} should be rejected"
+        );
+    }
+
+    #[test]
+    fn u64_overflow_schema_version_treated_as_too_new() {
+        // A malicious registry returning schema_version > u32::MAX should be rejected.
+        let json = r#"{"schema_version": 4294967297, "packs": {}}"#;
+        let raw: serde_json::Value = serde_json::from_str(json).unwrap();
+        let sv = raw.get("schema_version").and_then(|v| v.as_u64()).unwrap();
+        let sv = u32::try_from(sv).unwrap_or(u32::MAX);
+        assert_eq!(sv, u32::MAX, "overflow should map to u32::MAX");
+        assert!(sv > CURRENT_REGISTRY_SCHEMA_VERSION);
     }
 }

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -8,6 +8,9 @@ use crate::error::{Result, WeaveError};
 /// Bump when a registry format change ships that older clients must reject.
 pub const CURRENT_REGISTRY_SCHEMA_VERSION: u32 = 1;
 
+/// Serde default for registry metadata that predates schema versioning — always returns 1
+/// (the original schema), not `CURRENT_REGISTRY_SCHEMA_VERSION`. Files that omit
+/// the field were written before versioning existed and are implicitly version 1.
 fn default_registry_schema_version() -> u32 {
     1
 }
@@ -105,6 +108,8 @@ type SearchIndex = HashMap<String, PackListing>;
 /// (just the `packs` map at the top level, no wrapper).
 #[derive(Debug, Clone, Deserialize)]
 struct SearchIndexEnvelope {
+    // Checked before deserialization via raw JSON inspection in `parse_search_index`;
+    // retained for structural completeness so the envelope round-trips correctly.
     #[allow(dead_code)]
     schema_version: u32,
     packs: SearchIndex,
@@ -139,10 +144,7 @@ impl GitHubRegistry {
     }
 
     /// Fetch and cache the lightweight `index.json`.
-    ///
-    /// Supports two formats:
-    /// - **Envelope** (new): `{"schema_version": N, "packs": {…}}`
-    /// - **Flat** (legacy): `{"pack-name": {…}, …}` (no wrapper, defaults to schema v1)
+    /// Delegates format detection and version validation to [`Self::parse_search_index`].
     fn load_search_index(&self) -> Result<SearchIndex> {
         {
             let cache = self
@@ -170,19 +172,27 @@ impl GitHubRegistry {
 
     /// Parse `index.json`, trying the versioned envelope first, then the legacy
     /// flat format for backward compatibility with older registries and taps.
+    ///
+    /// - **Envelope** (new): `{"schema_version": N, "packs": {…}}`
+    /// - **Flat** (legacy): `{"pack-name": {…}, …}` (no wrapper, defaults to schema v1)
+    ///
+    /// Returns [`WeaveError::SchemaVersionTooNew`] if the envelope declares a
+    /// version newer than [`CURRENT_REGISTRY_SCHEMA_VERSION`].
     fn parse_search_index(&self, url: &str) -> Result<SearchIndex> {
         let raw: serde_json::Value =
             http_get_json(url, "registry search index", self.token.as_deref())?;
 
         // Try the new envelope format first: {"schema_version": N, "packs": {…}}
         if let Some(sv) = raw.get("schema_version").and_then(|v| v.as_u64()) {
-            let sv = sv as u32;
+            // Treat any value that overflows u32 as "too new" rather than silently truncating.
+            let sv = u32::try_from(sv).unwrap_or(u32::MAX);
             if sv > CURRENT_REGISTRY_SCHEMA_VERSION {
                 return Err(WeaveError::SchemaVersionTooNew {
                     file_kind: "registry search index",
                     path: url.into(),
                     found: sv,
                     supported: CURRENT_REGISTRY_SCHEMA_VERSION,
+                    current_version: env!("CARGO_PKG_VERSION"),
                 });
             }
             let envelope: SearchIndexEnvelope = serde_json::from_value(raw).map_err(|e| {
@@ -240,6 +250,7 @@ impl GitHubRegistry {
                 path: url.into(),
                 found: meta.schema_version,
                 supported: CURRENT_REGISTRY_SCHEMA_VERSION,
+                current_version: env!("CARGO_PKG_VERSION"),
             });
         }
 

--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -239,6 +239,7 @@ mod tests {
 
     fn pack_meta(name: &str, releases: Vec<PackRelease>) -> PackMetadata {
         PackMetadata {
+            schema_version: crate::core::registry::CURRENT_REGISTRY_SCHEMA_VERSION,
             name: name.into(),
             description: format!("{name} pack"),
             authors: vec![],

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,13 +144,15 @@ pub enum WeaveError {
 
     // Schema versioning errors
     #[error(
-        "{file_kind} at {path} uses schema version {found}, but this version of weave only supports up to version {supported} — please upgrade weave"
+        "{file_kind} at {path} uses schema version {found}, but weave v{current_version} only supports up to version {supported} — please upgrade: cargo install packweave"
     )]
     SchemaVersionTooNew {
         file_kind: &'static str,
         path: std::path::PathBuf,
         found: u32,
         supported: u32,
+        /// The running weave version, filled from `env!("CARGO_PKG_VERSION")`.
+        current_version: &'static str,
     },
 
     // Concurrency errors

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,6 +142,17 @@ pub enum WeaveError {
     #[error("tap '{name}' is not registered — run `weave tap list` to see registered taps")]
     TapNotFound { name: String },
 
+    // Schema versioning errors
+    #[error(
+        "{file_kind} at {path} uses schema version {found}, but this version of weave only supports up to version {supported} — please upgrade weave"
+    )]
+    SchemaVersionTooNew {
+        file_kind: &'static str,
+        path: std::path::PathBuf,
+        found: u32,
+        supported: u32,
+    },
+
     // Concurrency errors
     #[error(
         "another weave process is running — wait a moment and retry, or remove {lock_path} if this is unexpected"


### PR DESCRIPTION
## Summary

- Adds a `schema_version` (u32) field to `pack.toml`, all three adapter sidecar manifests (Claude Code, Codex CLI, Gemini CLI), and the lockfile
- Files without the field default to version 1 via `#[serde(default)]`, preserving backward compatibility with all existing files
- Loading any file with a schema version higher than the tool supports returns a clear `SchemaVersionTooNew` error directing users to upgrade weave
- `weave init` now emits `schema_version = 1` at the top of generated `pack.toml`
- `pack.schema.toml` updated to document the new field

## Test plan

- [x] `parse_pack_with_explicit_schema_version_1` — explicit version 1 works
- [x] `reject_pack_with_future_schema_version` — version 99 rejected with clear error
- [x] `parse_pack_without_schema_version_defaults_to_1` — existing packs still parse
- [x] `reject_manifest_with_future_schema_version` — one test per adapter (Claude Code, Codex CLI, Gemini CLI)
- [x] `reject_lockfile_with_future_schema_version` — lockfile version check
- [x] All existing tests continue to pass

Closes #224