### PR TITLE
docs: check off completed M6 items in ROADMAP.md

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -104,11 +104,11 @@ The milestones below are sequential. Each one produces something usable before t
 
 ### Security & Correctness
 
-- [ ] `--dry-run` flag on install/sync/remove — preview changes without writing (issue #166)
+- [x] `--dry-run` flag on install/sync/remove — preview changes without writing (issue #166)
 - [x] Concurrency lock to prevent simultaneous weave operations (issue #201)
 - [ ] Pack content checksums in registry for integrity verification (issue #175)
 - [x] Enforce `min_tool_version` check during pack install (issue #197)
-- [ ] Switch Codex adapter to `toml_edit` to preserve user comments (issue #212)
+- [x] Switch Codex adapter to `toml_edit` to preserve user comments (issue #212)
 - [x] Rollback on partial adapter apply failure — don't record install if any adapter fails (issue #221)
 - [x] Schema versioning for pack.toml and sidecar manifests — graceful rejection of newer formats (issue #224)
 


### PR DESCRIPTION
## Summary

- Mark `--dry-run` flag (#166) and Codex `toml_edit` (#212) as complete in M6 roadmap
- Both issues were closed as COMPLETED on 2026-03-24

## Test plan

- [x] Docs-only change — no code modifications
- [x] All tests pass